### PR TITLE
Optimize fertility chart rendering path for iOS WebKit scrolling

### DIFF
--- a/src/components/FertilityChart.jsx
+++ b/src/components/FertilityChart.jsx
@@ -6,7 +6,7 @@ import ChartPoints from '@/components/chartElements/ChartPoints';
 import ChartTooltip from '@/components/chartElements/ChartTooltip';
 import ChartLeftLegend from '@/components/chartElements/ChartLeftLegend';
 import { useFertilityChart } from '@/hooks/useFertilityChart';
-import { isAfter, parseISO, startOfDay } from 'date-fns';
+import { isIOSWebKit } from '@/lib/platform';
 
 const FertilityChart = ({
   data,
@@ -76,24 +76,28 @@ const FertilityChart = ({
     exportMode
   );
   const effectiveReduceMotion = reduceMotion || exportMode;
+  const isIOSWebKitDevice = useMemo(() => isIOSWebKit(), []);
+  const FULL_RENDER_THRESHOLD = 220;
   const uniqueIdRef = useRef(null);
   if (!uniqueIdRef.current) {
     const randomSuffix = Math.random().toString(36).slice(2, 10);
     uniqueIdRef.current = `fertility-chart-${cycleId ?? 'default'}-${randomSuffix}`;
   }
   const uniqueId = uniqueIdRef.current;
+  const fullRenderMode = allDataPoints.length <= FULL_RENDER_THRESHOLD;
   const getOverscanDays = useCallback((visibleDaysValue, totalPoints) => {
-    // En ciclos archivados priorizamos fluidez: render completo para tamaños medios.
-    const fullRenderThreshold = isArchivedCycle ? 220 : 120;
-    if (totalPoints <= fullRenderThreshold) return totalPoints;
+    if (totalPoints <= FULL_RENDER_THRESHOLD) return totalPoints;
 
-    const screens = isArchivedCycle
+    const iosOverscanScreens = isIOSWebKitDevice ? (visibleDaysValue >= 20 ? 4 : 6) : 0;
+    const baseScreens = isArchivedCycle
       ? (visibleDaysValue >= 20 ? 2 : 3)
       : (visibleDaysValue >= 20 ? 1 : 2);
+    const screens = Math.max(baseScreens, iosOverscanScreens);
     const raw = Math.ceil(visibleDaysValue * screens);
-    const capped = Math.min(raw, isArchivedCycle ? 48 : 24);
+    const cap = isIOSWebKitDevice ? (isArchivedCycle ? 84 : 72) : (isArchivedCycle ? 48 : 24);
+    const capped = Math.min(raw, cap);
     return Math.max(capped, 12);
-  }, [isArchivedCycle]);
+  }, [isArchivedCycle, isIOSWebKitDevice]);
 
   const initialRange = useMemo(() => {
     const total = allDataPoints.length;
@@ -112,6 +116,8 @@ const FertilityChart = ({
   const [visibleRange, setVisibleRange] = useState(initialRange);
   const scrollRafRef = useRef(null);
   const [isScrolling, setIsScrolling] = useState(false);
+  const isScrollingRef = useRef(false);
+  const lastFirstVisibleRef = useRef(null);
   const scrollStopTimerRef = useRef(null);
 
   const svgRef = useRef(null);
@@ -197,9 +203,7 @@ if (isRotated) {
     const point = allDataPoints[index];
     if (!point) return;
 
-    const isFuture = point.isoDate
-      ? isAfter(startOfDay(parseISO(point.isoDate)), startOfDay(new Date()))
-      : false;
+    const isFuture = Boolean(point.isFutureDay);
 
     if (isFuture) return;
 
@@ -914,6 +918,11 @@ useEffect(() => {
         setVisibleRange({ startIndex: 0, endIndex: -1 });
         return;
       }
+
+      if (fullRenderMode) {
+        setVisibleRange({ startIndex: 0, endIndex: totalPoints - 1 });
+        return;
+      }
       
       const viewportW = node.clientWidth || 1;
       const dayW = viewportW / Math.max(visibleDays, 1);
@@ -923,6 +932,15 @@ useEffect(() => {
 
       const firstVisible = Math.floor(scrollLeft / safeDayW);
       const lastVisible = Math.floor((scrollLeft + viewportW) / safeDayW);
+
+      const thresholdDays = isIOSWebKitDevice ? 2 : 1;
+      if (
+        Number.isInteger(lastFirstVisibleRef.current)
+        && Math.abs(firstVisible - lastFirstVisibleRef.current) < thresholdDays
+      ) {
+        return;
+      }
+      lastFirstVisibleRef.current = firstVisible;
 
       let startIndex = firstVisible - overscanDays;
       let endIndex = lastVisible + overscanDays;
@@ -935,14 +953,15 @@ useEffect(() => {
           : { startIndex, endIndex }
       );
     },
-    [allDataPoints.length, getOverscanDays, visibleDays]
+    [allDataPoints.length, fullRenderMode, getOverscanDays, isIOSWebKitDevice, visibleDays]
   );
 
   useEffect(() => {
     if (!chartRef.current) return;
     const dayWidth = chartRef.current.clientWidth / visibleDays;
     chartRef.current.scrollLeft = Math.max(0, dayWidth * initialScrollIndex);
-  updateVisibleRange(chartRef.current.scrollLeft);
+    lastFirstVisibleRef.current = null;
+    updateVisibleRange(chartRef.current.scrollLeft);
   }, [
     initialScrollIndex,
     visibleDays,
@@ -954,10 +973,37 @@ useEffect(() => {
   useEffect(() => {
     const node = chartRef.current;
     if (!node) return;
+
+    const setScrollingAttr = (value) => {
+      const attrValue = value ? '1' : '0';
+      node.setAttribute('data-scrolling', attrValue);
+      const svgNode = svgRef.current;
+      if (svgNode) {
+        svgNode.setAttribute('data-scrolling', attrValue);
+      }
+    };
+
+    setScrollingAttr(false);
+
     const handleScroll = () => {
-      setIsScrolling(true);
+      if (isIOSWebKitDevice) {
+        isScrollingRef.current = true;
+        setScrollingAttr(true);
+      } else {
+        setIsScrolling(true);
+      }
+
       if (scrollStopTimerRef.current) window.clearTimeout(scrollStopTimerRef.current);
-      scrollStopTimerRef.current = window.setTimeout(() => setIsScrolling(false), 140);
+      scrollStopTimerRef.current = window.setTimeout(() => {
+        if (isIOSWebKitDevice) {
+          isScrollingRef.current = false;
+          setScrollingAttr(false);
+        } else {
+          setIsScrolling(false);
+        }
+      }, 150);
+
+      if (fullRenderMode) return;
 
       if (scrollRafRef.current) return;
       scrollRafRef.current = window.requestAnimationFrame(() => {
@@ -968,6 +1014,7 @@ useEffect(() => {
     node.addEventListener('scroll', handleScroll, { passive: true });
     updateVisibleRange(node.scrollLeft);
     return () => {
+      setScrollingAttr(false);
       node.removeEventListener('scroll', handleScroll);
       if (scrollStopTimerRef.current) window.clearTimeout(scrollStopTimerRef.current);
       if (scrollRafRef.current) {
@@ -975,7 +1022,7 @@ useEffect(() => {
         scrollRafRef.current = null;
       }
     };
-  }, [updateVisibleRange]);
+  }, [fullRenderMode, isIOSWebKitDevice, updateVisibleRange]);
 
   const applyRotation = !exportMode && isFullScreen && forceLandscape && isViewportPortrait;
   const visualOrientation = forceLandscape ? 'landscape' : orientation;
@@ -1120,6 +1167,21 @@ const rotationStageStyle = isRotationStage
               <stop offset="0%" stopColor="rgba(244, 114, 182, 0.18)" />
               <stop offset="100%" stopColor="rgba(244, 114, 182, 0.02)" />
             </linearGradient>
+            <linearGradient id="tempLineGradientChartGlow" x1="0%" y1="0%" x2="100%" y2="0%">
+              <stop offset="0%" stopColor="#fbcfe8" />
+              <stop offset="50%" stopColor="#f472b6" />
+              <stop offset="100%" stopColor="#db2777" />
+            </linearGradient>
+            <linearGradient id="bgGradientChart" x1="0%" y1="0%" x2="0%" y2="100%">
+              <stop offset="0%" stopColor="#fffbfc" />
+              <stop offset="50%" stopColor="#fff5f7" />
+              <stop offset="100%" stopColor="#fff1f3" />
+            </linearGradient>
+            <linearGradient id="dataZoneGradient" x1="0%" y1="0%" x2="0%" y2="100%">
+              <stop offset="0%" stopColor="#fff7fb" />
+              <stop offset="50%" stopColor="#ffe4f0" />
+              <stop offset="100%" stopColor="#fff7fb" />
+            </linearGradient>
             
             <linearGradient id={relativePhaseGradientId} x1="0%" y1="0%" x2="0%" y2="100%">
               <stop offset="0%" stopColor="var(--phase-rel)" stopOpacity="0" />
@@ -1167,6 +1229,30 @@ const rotationStageStyle = isRotationStage
                 <feMergeNode in="SourceGraphic"/>
               </feMerge>
             </filter>
+            <filter id="softShadow">
+              <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+              <feOffset dx="0" dy="1" result="offsetblur"/>
+              <feComponentTransfer>
+                <feFuncA type="linear" slope="0.2"/>
+              </feComponentTransfer>
+              <feMerge>
+                <feMergeNode/>
+                <feMergeNode in="SourceGraphic"/>
+              </feMerge>
+            </filter>
+            <filter id="textShadow" x="-50%" y="-50%" width="200%" height="200%">
+              <feDropShadow dx="0" dy="1" stdDeviation="1" floodColor="rgba(255, 255, 255, 0.8)" />
+            </filter>
+            <filter id="lineShadow" x="-50%" y="-50%" width="200%" height="200%">
+              <feDropShadow dx="0" dy="2" stdDeviation="3" floodColor="rgba(244, 114, 182, 0.4)" />
+            </filter>
+            <filter id="lineGlow" x="-50%" y="-50%" width="200%" height="200%">
+              <feGaussianBlur stdDeviation="2" result="coloredBlur"/>
+              <feMerge>
+                <feMergeNode in="coloredBlur"/>
+                <feMergeNode in="SourceGraphic"/>
+              </feMerge>
+            </filter>
 
             {/* Filtro para el resplandor de la línea baseline */}
             <filter id="baselineGlow" x="-50%" y="-50%" width="200%" height="200%">
@@ -1176,6 +1262,24 @@ const rotationStageStyle = isRotationStage
                 <feMergeNode in="SourceGraphic"/>
               </feMerge>
             </filter>
+            <radialGradient id="tempPointGradientChart" cx="30%" cy="30%">
+              <stop offset="0%" stopColor="#FDF2F8" />
+              <stop offset="50%" stopColor="#F9A8D4" />
+              <stop offset="85%" stopColor="#EC4899" />
+              <stop offset="100%" stopColor="#DB2777" />
+            </radialGradient>
+
+            <radialGradient id="tempPointIgnoredGradient" cx="30%" cy="30%">
+              <stop offset="0%" stopColor="#FFFFFF" />
+              <stop offset="80%" stopColor="#F8FAFC" />
+              <stop offset="100%" stopColor="#E2E8F0" />
+            </radialGradient>
+            <radialGradient id="ovulationPointGradient" cx="30%" cy="30%">
+              <stop offset="0%" stopColor="#dbeafe" />
+              <stop offset="50%" stopColor="#93c5fd" />
+              <stop offset="85%" stopColor="#3b82f6" />
+              <stop offset="100%" stopColor="#2563eb" />
+            </radialGradient>
           </defs>
 
           {/* Fondo transparente para interacciones */}
@@ -1192,12 +1296,12 @@ const rotationStageStyle = isRotationStage
             getY={getY}
             getX={getX}
             allDataPoints={allDataPoints}
-            visibleRange={visibleRange}
+            visibleRange={fullRenderMode ? null : visibleRange}
             responsiveFontSize={responsiveFontSize}
             isFullScreen={isFullScreen}
             showLeftLabels={!showLegend}
             reduceMotion={effectiveReduceMotion}
-            isScrolling={isScrolling}
+            isScrolling={isIOSWebKitDevice ? false : isScrolling}
             graphBottomY={graphBottomY}
             chartAreaHeight={Math.max(chartHeight - padding.top - padding.bottom - (graphBottomInset || 0), 0)}
             rowsZoneHeight={rowsZoneHeight}
@@ -1413,7 +1517,7 @@ const rotationStageStyle = isRotationStage
             onPointInteraction={handlePointInteractionSafe}
             clearActivePoint={clearActivePointSafe}
             activePoint={activePoint}
-            visibleRange={visibleRange}
+            visibleRange={fullRenderMode ? null : visibleRange}
             padding={padding}
             chartHeight={chartHeight}
             chartWidth={chartWidth}
@@ -1423,7 +1527,7 @@ const rotationStageStyle = isRotationStage
             rowsZoneHeight={rowsZoneHeight}
             compact={false}
             reduceMotion={effectiveReduceMotion}
-            isScrolling={isScrolling}
+            isScrolling={isIOSWebKitDevice ? false : isScrolling}
             showInterpretation={showInterpretation}
             ovulationDetails={ovulationDetails}
             baselineStartIndex={baselineStartIndex}

--- a/src/components/chartElements/ChartAxes.jsx
+++ b/src/components/chartElements/ChartAxes.jsx
@@ -58,57 +58,6 @@ const ChartAxes = ({
   return (
     <>
 
-      {/* Definiciones mejoradas con gradientes inspirados en la dashboard */}
-      <defs>
-        <linearGradient id="bgGradientChart" x1="0%" y1="0%" x2="0%" y2="100%">
-          <stop offset="0%" stopColor="#fffbfc" />
-          <stop offset="50%" stopColor="#fff5f7" />
-          <stop offset="100%" stopColor="#fff1f3" />
-        </linearGradient>
-        {/* AÑADE ESTE NUEVO GRADIENTE */}
-<linearGradient id="dataZoneGradient" x1="0%" y1="0%" x2="0%" y2="100%">
-  <stop offset="0%"   stopColor="#fff7fb" />
-  <stop offset="50%"  stopColor="#ffe4f0" />
-  <stop offset="100%" stopColor="#fff7fb" />
-</linearGradient>
-
-        <linearGradient id="tempLineGradientChart" x1="0%" y1="0%" x2="100%" y2="0%">
-          <stop offset="0%" stopColor="#f472b6" />
-          <stop offset="30%" stopColor="#ec4899" />
-          <stop offset="70%" stopColor="#db2777" />
-          <stop offset="100%" stopColor="#be185d" />
-        </linearGradient>
-        
-        <filter id="softShadow">
-  <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
-  <feOffset dx="0" dy="1" result="offsetblur"/>
-  <feComponentTransfer>
-    <feFuncA type="linear" slope="0.2"/>
-  </feComponentTransfer>
-  <feMerge>
-    <feMergeNode/>
-    <feMergeNode in="SourceGraphic"/>
-  </feMerge>
-</filter>
-<filter id="pointGlow">
-  <feGaussianBlur stdDeviation="2" result="coloredBlur"/>
-  <feMerge>
-    <feMergeNode in="coloredBlur"/>
-    <feMergeNode in="SourceGraphic"/>
-  </feMerge>
-</filter>
-        
-        <filter id="textShadow" x="-50%" y="-50%" width="200%" height="200%">
-          <feDropShadow dx="0" dy="1" stdDeviation="1" floodColor="rgba(255, 255, 255, 0.8)" />
-        </filter>
-
-        {/* Patrón unificado para spotting */}
-        <pattern id="spotting-pattern-chart" patternUnits="userSpaceOnUse" width="6" height="6">
-          <rect width="6" height="6" fill="#ef4444" />
-          <circle cx="3" cy="3" r="1.5" fill="rgba(255,255,255,0.85)" />
-        </pattern>
-      </defs>
-
       {/* Fondo con gradiente elegante inspirado en la dashboard */}
       <rect
         x={padding.left}
@@ -284,4 +233,26 @@ const ChartAxes = ({
   );
 };
 
-export default ChartAxes;
+const areEqual = (prev, next) => (
+  prev.chartWidth === next.chartWidth
+  && prev.chartHeight === next.chartHeight
+  && prev.tempMin === next.tempMin
+  && prev.tempMax === next.tempMax
+  && prev.tempRange === next.tempRange
+  && prev.isFullScreen === next.isFullScreen
+  && prev.showLeftLabels === next.showLeftLabels
+  && prev.reduceMotion === next.reduceMotion
+  && prev.isScrolling === next.isScrolling
+  && prev.graphBottomY === next.graphBottomY
+  && prev.chartAreaHeight === next.chartAreaHeight
+  && prev.rowsZoneHeight === next.rowsZoneHeight
+  && prev.padding === next.padding
+  && prev.getX === next.getX
+  && prev.getY === next.getY
+  && prev.responsiveFontSize === next.responsiveFontSize
+  && prev.allDataPoints === next.allDataPoints
+  && prev.visibleRange?.startIndex === next.visibleRange?.startIndex
+  && prev.visibleRange?.endIndex === next.visibleRange?.endIndex
+);
+
+export default React.memo(ChartAxes, areEqual);

--- a/src/components/chartElements/ChartLine.jsx
+++ b/src/components/chartElements/ChartLine.jsx
@@ -61,20 +61,6 @@ const ChartLine = ({
 
   return (
     <>
-      {/* Definiciones para gradientes y filtros mejorados */}
-      <defs>
-        <linearGradient id="tempLineGradientChart" x1="0%" y1="0%" x2="100%" y2="0%">
-          <stop offset="0%" stopColor="#f472b6" />
-          <stop offset="30%" stopColor="#ec4899" />
-          <stop offset="70%" stopColor="#db2777" />
-          <stop offset="100%" stopColor="#be185d" />
-        </linearGradient>
-                
-        <filter id="lineShadow" x="-50%" y="-50%" width="200%" height="200%">
-          <feDropShadow dx="0" dy="2" stdDeviation="3" floodColor="rgba(244, 114, 182, 0.4)" />
-        </filter>
-      </defs>
-
       {/* Línea de respaldo con efecto glow */}
       {hasContinuousSegment && (
         reduceMotion ? (
@@ -87,6 +73,7 @@ const ChartLine = ({
             strokeLinejoin="round"
             opacity={0.4}
             style={{ filter: 'url(#lineGlow)' }}
+            className="fertility-chart-heavy-filter"
           />
         ) : (
           <motion.path
@@ -98,6 +85,7 @@ const ChartLine = ({
             strokeLinejoin="round"
             opacity={0.4}
             style={{ filter: 'url(#lineGlow)' }}
+            className="fertility-chart-heavy-filter"
             initial={{ pathLength: 0, opacity: 0 }}
             animate={{ pathLength: 1, opacity: 0.4 }}
             transition={{ duration: 0.8, ease: "easeInOut", delay: 0.2 }}
@@ -144,6 +132,7 @@ const ChartLine = ({
             strokeLinecap="round"
             strokeLinejoin="round"
             style={{ filter: 'url(#lineShadow)' }}
+            className="fertility-chart-heavy-filter"
           />
         ) : (
           <motion.path
@@ -154,6 +143,7 @@ const ChartLine = ({
             strokeLinecap="round"
             strokeLinejoin="round"
             style={{ filter: 'url(#lineShadow)' }}
+            className="fertility-chart-heavy-filter"
             initial={{ pathLength: 0, opacity: 0 }}
             animate={{ pathLength: 1, opacity: 1 }}
             transition={{ duration: 1, ease: "easeInOut", delay: 0.4 }}

--- a/src/components/chartElements/ChartPoints.jsx
+++ b/src/components/chartElements/ChartPoints.jsx
@@ -1,7 +1,6 @@
-import React, { useCallback, useEffect, useMemo, useRef } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { Heart } from 'lucide-react';
 import { motion } from 'framer-motion';
-import { parseISO, startOfDay, isAfter, isSameDay } from 'date-fns';
 import { getSymbolAppearance, getSymbolColorPalette } from '@/config/fertilitySymbols';
 // Colores consistentes con la dashboard pero con mejor contraste para el chart
 const SENSATION_COLOR = 'var(--color-sensacion-fuerte)';
@@ -265,9 +264,7 @@ const ChartPoints = ({
     : Math.max(totalPoints - 1, 0);
   const startIndex = totalPoints ? Math.max(0, Math.min(totalPoints - 1, rangeStart)) : 0;
   const endIndex = totalPoints ? Math.max(startIndex, Math.min(totalPoints - 1, rangeEnd)) : -1;
-  const today = useMemo(() => startOfDay(new Date()), []);
   const measureTextWidth = useMemo(() => createTextMeasurer(), []);
-  const textLayoutCacheRef = useRef(new Map());
   const cellWidth = totalPoints > 0 ? rowWidth / totalPoints : rowWidth;
   const maxWords = 2;
   const cellTextPadding = Math.min(12, Math.max(4, cellWidth * 0.12));
@@ -449,26 +446,43 @@ for (let i = orderedAscending.length - 1; i >= 0; i -= 1) {
     [availableTextWidth, measureTextWidth]
   );
 
-  useEffect(() => {
-    textLayoutCacheRef.current.clear();
-  }, [
-    totalPoints,
-    availableTextWidth,
-    baseSensationFontSize,
-    baseAppearanceFontSize,
-    baseObservationFontSize,
-  ]);
 
-  const getCachedLines = useCallback(
-    (cacheKey, text, fallback, baseFontSize, smallFontSize) => {
-      const existing = textLayoutCacheRef.current.get(cacheKey);
-      if (existing) return existing;
-      const resolved = resolveLines(text, fallback, baseFontSize, smallFontSize);
-      textLayoutCacheRef.current.set(cacheKey, resolved);
-      return resolved;
-    },
-    [resolveLines]
-  );
+
+  const precomputedLayouts = useMemo(() => {
+    const map = new Map();
+    data.forEach((point, index) => {
+      if (!point) return;
+      const isFuture = Boolean(point.isFutureDay);
+
+      const sensText = isFullScreen
+        ? limitWords(point.mucus_sensation, maxWords, isFuture ? '' : '–')
+        : point.mucus_sensation;
+      const aparText = isFullScreen
+        ? limitWords(point.mucus_appearance, maxWords, isFuture ? '' : '–')
+        : point.mucus_appearance;
+      const obsText = isFullScreen
+        ? limitWords(point.observations, maxWords, '')
+        : point.observations;
+
+      map.set(index, {
+        sens: resolveLines(sensText, isFuture ? '' : '–', baseSensationFontSize, smallSensationFontSize),
+        apar: resolveLines(aparText, isFuture ? '' : '–', baseAppearanceFontSize, smallAppearanceFontSize),
+        obs: resolveLines(obsText, '', baseObservationFontSize, smallObservationFontSize),
+      });
+    });
+    return map;
+  }, [
+    data,
+    isFullScreen,
+    maxWords,
+    resolveLines,
+    baseSensationFontSize,
+    smallSensationFontSize,
+    baseAppearanceFontSize,
+    smallAppearanceFontSize,
+    baseObservationFontSize,
+    smallObservationFontSize,
+  ]);
 
   const visibleIndices = useMemo(() => {
     if (!totalPoints || endIndex < startIndex) return [];
@@ -477,45 +491,6 @@ for (let i = orderedAscending.length - 1; i >= 0; i -= 1) {
 
   return (
     <>
-      {/* Definiciones mejoradas con estilo premium */}
-      <defs>
-        <filter id="rowShadowChart" x="-10%" y="-10%" width="120%" height="120%">
-          <feDropShadow dx="0" dy="2" stdDeviation="4" floodColor="rgba(244, 114, 182, 0.2)" />
-        </filter>
-        <pattern id="spotting-pattern-chart" patternUnits="userSpaceOnUse" width="6" height="6">
-          <rect width="6" height="6" fill="#fb7185" />
-          <circle cx="3" cy="3" r="1.5" fill="rgba(255,255,255,0.85)" />
-        </pattern>
-        
-        <filter id="pointGlow" x="-50%" y="-50%" width="200%" height="200%">
-          <feGaussianBlur stdDeviation="3" result="coloredBlur"/>
-          <feMerge>
-            <feMergeNode in="coloredBlur"/>
-            <feMergeNode in="SourceGraphic"/>
-          </feMerge>
-        </filter>
-
-
-        <radialGradient id="tempPointGradientChart" cx="30%" cy="30%">
-          <stop offset="0%" stopColor="#FDF2F8" />
-          <stop offset="50%" stopColor="#F9A8D4" />
-          <stop offset="85%" stopColor="#EC4899" />
-          <stop offset="100%" stopColor="#DB2777" />
-        </radialGradient>
-
-        <radialGradient id="tempPointIgnoredGradient" cx="30%" cy="30%">
-          <stop offset="0%" stopColor="#FFFFFF" />
-          <stop offset="80%" stopColor="#F8FAFC" />
-          <stop offset="100%" stopColor="#E2E8F0" />
-        </radialGradient>
-        <radialGradient id="ovulationPointGradient" cx="30%" cy="30%">
-          <stop offset="0%" stopColor="#dbeafe" />
-          <stop offset="50%" stopColor="#93c5fd" />
-          <stop offset="85%" stopColor="#3b82f6" />
-          <stop offset="100%" stopColor="#2563eb" />
-        </radialGradient>
-      </defs>
-
       {/* Fondos de filas sutiles alineados con las tarjetas -- ocultos en modo compacto */}
 
 
@@ -606,9 +581,7 @@ for (let i = orderedAscending.length - 1; i >= 0; i -= 1) {
           : (symbolInfo.value === 'white' ? 1.6 : 1);
 
 
-        const isFuture = point.isoDate
-          ? isAfter(startOfDay(parseISO(point.isoDate)), startOfDay(new Date()))
-          : false;
+        const isFuture = Boolean(point.isFutureDay);
 
           const symbolRectSize = responsiveFontSize(isFullScreen ? 1.8 : 2);
           const symbolTextY = symbolRowYBase - symbolRectSize * 0.75 + symbolRectSize / 2 + 2;
@@ -630,9 +603,7 @@ for (let i = orderedAscending.length - 1; i >= 0; i -= 1) {
             }
           : {};
 
-        const isTodayPoint = point.isoDate
-          ? isSameDay(parseISO(point.isoDate), today)
-          : false;
+        const isTodayPoint = Boolean(point.isToday);
         const highlightedTextFill = isTodayPoint ? TODAY_HIGHLIGHT_COLOR : baseTextFill;
 
         const hasHighOrder = highSequenceOrderMap.has(index);
@@ -658,28 +629,10 @@ const obsText = isFullScreen
   ? limitWords(point.observations, maxWords, '')
   : point.observations;
 
-const pointKey = `${point.isoDate || point.id || index}`;
-const sensRes = getCachedLines(
-  `${pointKey}-sens-${availableTextWidth}-${baseSensationFontSize}-${smallSensationFontSize}-${sensText ?? ''}`,
-  sensText,
-  isFuture ? '' : '–',
-  baseSensationFontSize,
-  smallSensationFontSize
-);
-const aparRes = getCachedLines(
-  `${pointKey}-apar-${availableTextWidth}-${baseAppearanceFontSize}-${smallAppearanceFontSize}-${aparText ?? ''}`,
-  aparText,
-  isFuture ? '' : '–',
-  baseAppearanceFontSize,
-  smallAppearanceFontSize
-);
-const obsRes = getCachedLines(
-  `${pointKey}-obs-${availableTextWidth}-${baseObservationFontSize}-${smallObservationFontSize}-${obsText ?? ''}`,
-  obsText,
-  '',
-  baseObservationFontSize,
-  smallObservationFontSize
-);
+const pointLayout = precomputedLayouts.get(index);
+const sensRes = pointLayout?.sens ?? resolveLines(sensText, isFuture ? '' : '–', baseSensationFontSize, smallSensationFontSize);
+const aparRes = pointLayout?.apar ?? resolveLines(aparText, isFuture ? '' : '–', baseAppearanceFontSize, smallAppearanceFontSize);
+const obsRes = pointLayout?.obs ?? resolveLines(obsText, '', baseObservationFontSize, smallObservationFontSize);
 
 const [sensLine1, sensLine2, sensLine3] = sensRes.lines;
 const [aparLine1, aparLine2, aparLine3] = aparRes.lines;

--- a/src/hooks/useFertilityChart.js
+++ b/src/hooks/useFertilityChart.js
@@ -894,16 +894,31 @@ export const useFertilityChart = (
     ]
   );
 
-  const processedDataWithAssessments = useMemo(
-    () =>
-      processedData.map((entry, index) => {
-        if (!entry) return entry;
-        const isFutureDay = Number.isInteger(todayIndex) ? index > todayIndex : false;
-        // Ya no añadimos fertilityAssessment: solo marcamos si es futuro
-        return { ...entry, isFutureDay };
-      }),
-    [processedData, todayIndex]
-  );
+  const processedDataWithAssessments = useMemo(() => {
+    const now = new Date();
+    const todayStartTs = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+
+    return processedData.map((entry, index) => {
+      if (!entry) return entry;
+
+      let isoTs = null;
+      let dayStartTs = null;
+      if (entry.isoDate) {
+        const parsed = parseISO(entry.isoDate);
+        if (!Number.isNaN(parsed.getTime())) {
+          isoTs = parsed.getTime();
+          dayStartTs = new Date(parsed.getFullYear(), parsed.getMonth(), parsed.getDate()).getTime();
+        }
+      }
+
+      const isToday = dayStartTs != null && dayStartTs === todayStartTs;
+      const isFutureDay = Number.isInteger(todayIndex)
+        ? index > todayIndex
+        : dayStartTs != null && dayStartTs > todayStartTs;
+
+      return { ...entry, isoTs, dayStartTs, isToday, isFutureDay };
+    });
+  }, [processedData, todayIndex]);
 
   const allDataPoints = useMemo(
     () => processedDataWithAssessments.filter((d) => d && d.isoDate),

--- a/src/index.css
+++ b/src/index.css
@@ -603,3 +603,7 @@ button.date-editor-toggle[aria-pressed="true"] {
 button.date-editor-toggle[aria-pressed="true"] svg {
   stroke: currentColor !important;
 }
+[data-scrolling="1"] .fertility-chart-heavy-filter,
+[data-scrolling="1"] .fertility-chart-heavy-filter * {
+  filter: none !important;
+}

--- a/src/lib/platform.js
+++ b/src/lib/platform.js
@@ -1,0 +1,11 @@
+export const isIOSWebKit = () => {
+  if (typeof navigator === 'undefined') return false;
+
+  const ua = navigator.userAgent || '';
+  const isIOSDevice = /iPhone|iPad|iPod/i.test(ua)
+    || (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+  const isWebKit = /WebKit/i.test(ua) && !/CriOS|FxiOS|OPiOS|EdgiOS/i.test(ua);
+  const hasCapacitor = typeof window !== 'undefined' && Boolean(window?.Capacitor);
+
+  return isIOSDevice && (isWebKit || hasCapacitor);
+};


### PR DESCRIPTION
### Motivation
- Address janky/frozen behavior on iOS (Safari / WebKit in Capacitor) caused by frequent React state churn and expensive per-point work during horizontal scroll/rotation while keeping the UI identical in appearance and interaction.
- Avoid regressions on Android by scoping aggressive optimizations to iOS WebKit or very long cycles and only changing when/where work is computed, not what is drawn.

### Description
- Add platform detection helper `isIOSWebKit` and use it to enable iOS-specific strategies (new file: `src/lib/platform.js`).
- Implement a FULL_RENDER mode (threshold = 220 points) that disables per-scroll windowing and stabilizes `visibleRange` so small scroll gestures do not trigger re-renders (changes in `src/components/FertilityChart.jsx`).
- For windowed mode on long cycles, increase overscan for iOS and only update `visibleRange` when the visible day index moves by a threshold (reduces pop-in and frequent updates).
- Remove per-point date parsing in render and precompute per-day metadata (`isoTs`, `dayStartTs`, `isToday`, `isFutureDay`) in `useFertilityChart` (`src/hooks/useFertilityChart.js`) so render layers read flags instead of parsing dates.
- Move text layout/measure work out of the per-point render path into a memoized precomputation in `ChartPoints` (consume `precomputedLayouts` instead of measuring per render), eliminating measureText spikes (`src/components/chartElements/ChartPoints.jsx`).
- Consolidate heavy SVG `defs` (gradients/filters/patterns) in the parent SVG (`FertilityChart`) and remove duplicated defs from child components; add missing glow/filter IDs used by `ChartLine` so visual output is unchanged (`src/components/FertilityChart.jsx`, `src/components/chartElements/ChartLine.jsx`, `src/components/chartElements/ChartAxes.jsx`, `src/components/chartElements/ChartPoints.jsx`).
- Replace scroll-time `setState` churn for iOS with a `data-scrolling` attribute toggled on the scroll container/SVG (no React rerender) and add a CSS rule to temporarily disable heavy filters while scrolling to avoid expensive WebKit recomposites (`src/index.css`).
- Add `React.memo` with a custom comparator to `ChartAxes` to avoid rerenders of static layers when irrelevant props keep changing, and add small stability changes to `ChartLine` to mark heavy-filter elements with a class for CSS control (`src/components/chartElements/ChartAxes.jsx`, `src/components/chartElements/ChartLine.jsx`).

### Testing
- Built production bundle successfully (`npm run build`) and the build completed without errors.
- Launched the dev server and verified the app runs; a visual verification screenshot of the running app was captured from the local server.
- Performed local runtime checks to confirm the chart renders and that scroll handling path toggles the `data-scrolling` attribute (no automated unit tests were modified or added).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5bc8676fc83339483b6fb1721cff7)