### PR TITLE
Refactor chart rendering: shared theme/ids/layout + Canvas+SVG hybrid overlay

### DIFF
--- a/src/components/FertilityChart.jsx
+++ b/src/components/FertilityChart.jsx
@@ -5,7 +5,11 @@ import ChartLine from '@/components/chartElements/ChartLine';
 import ChartPoints from '@/components/chartElements/ChartPoints';
 import ChartTooltip from '@/components/chartElements/ChartTooltip';
 import ChartLeftLegend from '@/components/chartElements/ChartLeftLegend';
+import ChartSvgDefs from '@/components/chartElements/ChartSvgDefs';
 import FertilityChartCanvas from '@/components/FertilityChartCanvas';
+import { THEME } from '@/components/chartElements/chartTheme';
+import { createChartIds } from '@/components/chartElements/chartIds';
+import { computeVisibleRange } from '@/components/chartElements/chartVisibleRange';
 import { useFertilityChart } from '@/hooks/useFertilityChart';
 import { isAfter, parseISO, startOfDay } from 'date-fns';
 
@@ -90,32 +94,17 @@ const FertilityChart = ({
     uniqueIdRef.current = `fertility-chart-${cycleId ?? 'default'}-${randomSuffix}`;
   }
   const uniqueId = uniqueIdRef.current;
-  const getOverscanDays = useCallback((visibleDaysValue, totalPoints) => {
-    // En ciclos archivados priorizamos fluidez: render completo para tamaños medios.
-    const fullRenderThreshold = isArchivedCycle ? 220 : 120;
-    if (totalPoints <= fullRenderThreshold) return totalPoints;
-
-    const screens = isArchivedCycle
-      ? (visibleDaysValue >= 20 ? 2 : 3)
-      : (visibleDaysValue >= 20 ? 1 : 2);
-    const raw = Math.ceil(visibleDaysValue * screens);
-    const capped = Math.min(raw, isArchivedCycle ? 48 : 24);
-    return Math.max(capped, 12);
-  }, [isArchivedCycle]);
+  const ids = useMemo(() => createChartIds(uniqueId), [uniqueId]);
+  const theme = THEME;
+  const xs = useMemo(() => allDataPoints.map((_, i) => getX(i)), [allDataPoints, getX]);
 
   const initialRange = useMemo(() => {
     const total = allDataPoints.length;
     if (!total) return { startIndex: 0, endIndex: -1 };
-
-    const overscanDays = getOverscanDays(visibleDays, total);
-    const startIndex = Math.max(0, Math.floor(initialScrollIndex) - overscanDays);
-    const endIndex = Math.min(
-      total - 1,
-      Math.floor(initialScrollIndex) + visibleDays + overscanDays
-    );
-
-    return { startIndex, endIndex };
-  }, [allDataPoints.length, getOverscanDays, initialScrollIndex, visibleDays]);
+    const safeStart = Math.max(0, Math.floor(initialScrollIndex));
+    const safeEnd = Math.min(total - 1, safeStart + visibleDays);
+    return { startIndex: safeStart, endIndex: safeEnd };
+  }, [allDataPoints.length, initialScrollIndex, visibleDays]);
 
   const [visibleRange, setVisibleRange] = useState(initialRange);
   const scrollRafRef = useRef(null);
@@ -911,39 +900,12 @@ useEffect(() => {
   };
 }, []);
 
-  const updateVisibleRange = useCallback(
-    (scrollLeft = 0) => {
-      const node = chartRef.current;
-      if (!node) return;
-
-      const totalPoints = allDataPoints.length;
-      if (!totalPoints) {
-        setVisibleRange({ startIndex: 0, endIndex: -1 });
-        return;
-      }
-      
-      const viewportW = node.clientWidth || 1;
-      const dayW = viewportW / Math.max(visibleDays, 1);
-      const safeDayW = dayW || 1;
-
-      const overscanDays = getOverscanDays(visibleDays, totalPoints);
-
-      const firstVisible = Math.floor(scrollLeft / safeDayW);
-      const lastVisible = Math.floor((scrollLeft + viewportW) / safeDayW);
-
-      let startIndex = firstVisible - overscanDays;
-      let endIndex = lastVisible + overscanDays;
-
-      startIndex = Math.max(0, startIndex);
-      endIndex = Math.min(totalPoints - 1, endIndex);
-      setVisibleRange((prev) =>
-        prev.startIndex === startIndex && prev.endIndex === endIndex
-          ? prev
-          : { startIndex, endIndex }
-      );
-    },
-    [allDataPoints.length, getOverscanDays, visibleDays]
-  );
+  const updateVisibleRange = useCallback((scrollLeft = 0) => {
+    const node = chartRef.current;
+    if (!node) return;
+    const next = computeVisibleRange({ xs, scrollLeft, viewportW: node.clientWidth || 1 });
+    setVisibleRange((prev) => (prev.startIndex === next.startIndex && prev.endIndex === next.endIndex ? prev : next));
+  }, [xs, chartRef]);
 
   useEffect(() => {
     if (!chartRef.current) return;
@@ -1059,6 +1021,32 @@ const rotationStageStyle = isRotationStage
   const handlePointInteractionSafe = exportMode ? () => {} : handlePointInteraction;
   const clearActivePointSafe = exportMode ? () => {} : clearActivePoint;
   const useCanvasRenderer = USE_CANVAS && !exportMode;
+  const overlayGroupRef = useRef(null);
+  const overlayRafRef = useRef(null);
+
+  useEffect(() => {
+    if (!useCanvasRenderer) return;
+    const node = chartRef.current;
+    if (!node) return;
+    const syncOverlay = () => {
+      if (!overlayGroupRef.current) return;
+      overlayGroupRef.current.setAttribute('transform', `translate(${-node.scrollLeft}, ${-node.scrollTop})`);
+    };
+    syncOverlay();
+    const onScroll = () => {
+      if (overlayRafRef.current) return;
+      overlayRafRef.current = window.requestAnimationFrame(() => {
+        overlayRafRef.current = null;
+        syncOverlay();
+      });
+    };
+    node.addEventListener('scroll', onScroll, { passive: true });
+    return () => {
+      node.removeEventListener('scroll', onScroll);
+      if (overlayRafRef.current) cancelAnimationFrame(overlayRafRef.current);
+      overlayRafRef.current = null;
+    };
+  }, [useCanvasRenderer, chartRef]);
   return (
       <motion.div className="relative w-full h-full" initial={false}>
       
@@ -1103,6 +1091,8 @@ const rotationStageStyle = isRotationStage
                     graphBottomY={graphBottomY}
                     rowsZoneHeight={rowsZoneHeight}
                     showRelationsRow={showRelationsRow}
+                    ids={ids}
+                    theme={theme}
                   />
                 </div>
               )}
@@ -1112,6 +1102,7 @@ const rotationStageStyle = isRotationStage
   </div>
 )}
               {useCanvasRenderer ? (
+                <>
                 <FertilityChartCanvas
                 chartRef={chartRef}
                 allDataPoints={allDataPoints}  
@@ -1147,8 +1138,59 @@ const rotationStageStyle = isRotationStage
                   showRelationsRow={showRelationsRow}
                   isScrolling={isScrolling}
                   showLegend={showLegend}
+                  visibleRange={visibleRange}
                 />
-              ) : (
+ 
+                {useCanvasRenderer && (
+                  <svg
+                    className="pointer-events-none absolute inset-0 z-20"
+                    width={chartWidth}
+                    height={scrollableContentHeight}
+                    viewBox={`0 0 ${chartWidth} ${scrollableContentHeight}`}
+                    preserveAspectRatio="none"
+                    style={{ position: 'sticky', left: 0, top: 0 }}
+                  >
+                    <ChartSvgDefs ids={ids} theme={theme} />
+                    <g ref={overlayGroupRef}>
+                      <ChartPoints
+                        data={allDataPoints}
+                        getX={getX}
+                        getY={getY}
+                        isFullScreen={isFullScreen}
+                        orientation={visualOrientation}
+                        responsiveFontSize={responsiveFontSize}
+                        onPointInteraction={handlePointInteractionSafe}
+                        clearActivePoint={clearActivePointSafe}
+                        activePoint={activePoint}
+                        visibleRange={visibleRange}
+                        padding={padding}
+                        chartHeight={chartHeight}
+                        chartWidth={chartWidth}
+                        temperatureField="displayTemperature"
+                        textRowHeight={textRowHeight}
+                        graphBottomY={graphBottomY}
+                        rowsZoneHeight={rowsZoneHeight}
+                        compact={false}
+                        reduceMotion={effectiveReduceMotion}
+                        isScrolling={isScrolling}
+                        showInterpretation={showInterpretation}
+                        ovulationDetails={ovulationDetails}
+                        baselineStartIndex={baselineStartIndex}
+                        firstHighIndex={firstHighIndex}
+                        baselineIndices={baselineIndices}
+                        graphBottomLift={graphBottomInset}
+                        showRelationsRow={showRelationsRow}
+                        autoLabelStep={exportMode}
+                        isArchivedCycle={isArchivedCycle}
+                        ids={ids}
+                        theme={theme}
+                        renderMode="rowsOnly"
+                      />
+                    </g>
+                  </svg>
+                )}
+                </>
+             ) : (
               <motion.svg
                 ref={svgRef}
                 width={chartWidth}
@@ -1160,18 +1202,6 @@ const rotationStageStyle = isRotationStage
                 initial={false}
               >
           <defs>
-            {/* Gradientes mejorados para la línea de temperatura */}
-            <linearGradient id="tempLineGradientChart" x1="0%" y1="0%" x2="100%" y2="0%">
-              <stop offset="0%" stopColor="#F472B6" />
-              <stop offset="50%" stopColor="#EC4899" />
-              <stop offset="100%" stopColor="#E91E63" />
-            </linearGradient>
-            
-            <linearGradient id="tempAreaGradientChart" x1="0%" y1="0%" x2="0%" y2="100%">
-              <stop offset="0%" stopColor="rgba(244, 114, 182, 0.18)" />
-              <stop offset="100%" stopColor="rgba(244, 114, 182, 0.02)" />
-            </linearGradient>
-            
             <linearGradient id={relativePhaseGradientId} x1="0%" y1="0%" x2="0%" y2="100%">
               <stop offset="0%" stopColor="var(--phase-rel)" stopOpacity="0" />
               <stop
@@ -1204,35 +1234,13 @@ const rotationStageStyle = isRotationStage
                 stopOpacity="var(--phase-post-abs-stop, 0.7)"
               />
             </linearGradient>
-            {/* Patrón unificado para spotting */}
-            <pattern id="spotting-pattern-chart" patternUnits="userSpaceOnUse" width="6" height="6">
-              <rect width="6" height="6" fill="#ef4444" />
-              <circle cx="3" cy="3" r="1.5" fill="rgba(255,255,255,0.85)" />
-            </pattern>
-
-            {/* Filtros para efectos de sombra */}
-            <filter id="chartShadow" x="-50%" y="-50%" width="200%" height="200%">
-              <feGaussianBlur stdDeviation="2" result="coloredBlur"/>
-              <feMerge>
-                <feMergeNode in="coloredBlur"/>
-                <feMergeNode in="SourceGraphic"/>
-              </feMerge>
-            </filter>
-
-            {/* Filtro para el resplandor de la línea baseline */}
-            <filter id="baselineGlow" x="-50%" y="-50%" width="200%" height="200%">
-              <feGaussianBlur stdDeviation="1.5" result="coloredBlur"/>
-              <feMerge>
-                <feMergeNode in="coloredBlur"/>
-                <feMergeNode in="SourceGraphic"/>
-              </feMerge>
-            </filter>
           </defs>
 
           {/* Fondo transparente para interacciones */}
           <rect width="100%" height="100%" fill="transparent" pointerEvents="all" />
 
           {/* Ejes del gráfico */}
+          <ChartSvgDefs ids={ids} theme={theme} />
           <ChartAxes
             padding={padding}
             chartWidth={chartWidth}
@@ -1252,6 +1260,8 @@ const rotationStageStyle = isRotationStage
             graphBottomY={graphBottomY}
             chartAreaHeight={Math.max(chartHeight - padding.top - padding.bottom - (graphBottomInset || 0), 0)}
             rowsZoneHeight={rowsZoneHeight}
+            ids={ids}
+            theme={theme}
           />
           {showInterpretation &&
             interpretationSegments.length > 0 &&
@@ -1405,6 +1415,8 @@ const rotationStageStyle = isRotationStage
             temperatureField="displayTemperature"
             reduceMotion={effectiveReduceMotion}
             connectGaps={!exportMode}
+            ids={ids}
+            theme={theme}
           />
           {temperatureRiseHighlightPath && (
             <g pointerEvents="none">
@@ -1484,6 +1496,8 @@ const rotationStageStyle = isRotationStage
             showRelationsRow={showRelationsRow}
             autoLabelStep={exportMode}
             isArchivedCycle={isArchivedCycle}
+            ids={ids}
+            theme={theme}
           />
 
         </motion.svg>

--- a/src/components/FertilityChartCanvas.jsx
+++ b/src/components/FertilityChartCanvas.jsx
@@ -1,72 +1,8 @@
 import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import { isAfter, parseISO, startOfDay } from 'date-fns';
-import { getSymbolAppearance, getSymbolColorPalette } from '@/config/fertilitySymbols';
+import { getCanvasTheme, FONT_FAMILY } from '@/components/chartElements/chartTheme';
+import { getTempTicks } from '@/components/chartElements/chartTicks';
 
-const SENSATION_COLOR = 'var(--color-sensacion-fuerte)';
-const APPEARANCE_COLOR = 'var(--color-apariencia-fuerte)';
-const OBSERVATION_COLOR = 'var(--color-observaciones-fuerte)';
-const DEFAULT_TEXT_FONT_FAMILY = '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif';
-
-const limitWords = (str = '', maxWords, fallback = '–') => {
-  if (!str) return fallback;
-  return str.split(/\s+/).slice(0, maxWords).join(' ');
-};
-
-const splitTextLinesByWidth = (ctx, str = '', { maxWidth, maxLines = 3, fontSize, fallback = '–' }) => {
-  if (!str) return [fallback, ...Array.from({ length: Math.max(0, maxLines - 1) }, () => '')];
-  const normalized = String(str).trim();
-  const hasSpaces = /\s/.test(normalized);
-  const tokens = hasSpaces ? normalized.split(/\s+/) : Array.from(normalized);
-  const sep = hasSpaces ? ' ' : '';
-  const lines = [];
-  const textWidth = (text) => ctx.measureText(text).width;
-
-  while (tokens.length && lines.length < maxLines) {
-    let line = '';
-    while (tokens.length) {
-      const next = tokens[0];
-      const candidate = line ? `${line}${sep}${next}` : next;
-      if (textWidth(candidate) <= maxWidth || !line) {
-        line = candidate;
-        tokens.shift();
-      } else {
-        break;
-      }
-    }
-    lines.push(line);
-  }
-
-  if (tokens.length && lines.length) {
-    let last = lines[lines.length - 1] || '';
-    while (last && textWidth(`${last}…`) > maxWidth) last = last.slice(0, -1);
-    lines[lines.length - 1] = last ? `${last}…` : '…';
-  }
-  while (lines.length < maxLines) lines.push('');
-  return lines;
-};
-
-const compactDate = (dateStr) => {
-  if (!dateStr) return '';
-  const [d, m] = String(dateStr).split('/');
-  return `${parseInt(d, 10)}/${parseInt(m, 10)}`;
-};
-
-const getLabelStep = ({ totalPoints, getX, responsiveFontSize, data, ctx }) => {
-  if (totalPoints < 2 || !ctx) return 1;
-  const dayWidth = Math.abs(getX(1) - getX(0));
-  if (!Number.isFinite(dayWidth) || dayWidth <= 0) return 1;
-  const samplePoint = data?.find((entry) => entry?.date || entry?.cycleDay != null) ?? {};
-  const sampleDate = compactDate(samplePoint?.date || '00/00');
-  const sampleDay = String(samplePoint?.cycleDay ?? totalPoints ?? '');
-  ctx.font = `900 ${responsiveFontSize(1.05)}px -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif`;
-  const dateWidth = ctx.measureText(sampleDate).width;
-  ctx.font = `900 ${responsiveFontSize(1)}px -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif`;
-  const dayWidthText = ctx.measureText(sampleDay).width;
-  const minLabelWidth = Math.max(dateWidth, dayWidthText) + responsiveFontSize(0.8);
-  return Math.max(1, Math.ceil(minLabelWidth / dayWidth));
-};
-
-// Helper: rounded rect compatible (sin depender de ctx.roundRect)
 const buildRoundRectPath = (ctx, x, y, w, h, r) => {
   const radius = Math.max(0, Math.min(r, w / 2, h / 2));
   ctx.beginPath();
@@ -77,6 +13,7 @@ const buildRoundRectPath = (ctx, x, y, w, h, r) => {
   ctx.arcTo(x, y, x + w, y, radius);
   ctx.closePath();
 };
+
 const FertilityChartCanvas = ({
   chartRef,
   chartWidth,
@@ -85,7 +22,6 @@ const FertilityChartCanvas = ({
   padding,
   graphBottomY,
   rowsZoneHeight,
-  textRowHeight,
   allDataPoints = [],
   tempMin,
   tempMax,
@@ -107,69 +43,26 @@ const FertilityChartCanvas = ({
   todayIndex,
   handlePointInteraction,
   isRotatedForInput,
-  isFullScreen = false,
-  showRelationsRow = false,
   isScrolling = false,
-  showLeftLegend = false,
+  showLegend = false,
+  visibleRange,
 }) => {
   const canvasRef = useRef(null);
   const rafRef = useRef(null);
   const xsRef = useRef([]);
   const ysTempRef = useRef([]);
-  const visibleRef = useRef({ start: 0, end: -1 });
   const canvasSizeRef = useRef({ viewportW: 0, viewportH: 0, dpr: 0 });
   const pointerStateRef = useRef(null);
-  const textLayoutCacheRef = useRef(new Map());
-  const spottingPatternRef = useRef(null); 
+  const theme = useMemo(() => getCanvasTheme(), []);
+  const tempTicks = useMemo(() => getTempTicks({ tempMin, tempMax, tempRange }), [tempMin, tempMax, tempRange]);
 
-  useEffect(() => {
-    xsRef.current = allDataPoints.map((_, i) => getX(i));
-  }, [allDataPoints, getX]);
-
+  useEffect(() => { xsRef.current = allDataPoints.map((_, i) => getX(i)); }, [allDataPoints, getX]);
   useEffect(() => {
     ysTempRef.current = allDataPoints.map((point) => {
       const temp = point?.displayTemperature;
       return Number.isFinite(temp) ? getY(temp) : null;
     });
-  }, [allDataPoints, getY, tempMin, tempMax]);
-
-  const tempTicks = useMemo(() => {
-    const ticks = [];
-    if (tempRange > 0) {
-      const inc = tempRange <= 2.5 ? 0.1 : 0.5;
-      for (let t = tempMin; t <= tempMax + 1e-9; t += inc) ticks.push(Number(t.toFixed(1)));
-      return ticks;
-    }
-    for (let t = 35.8; t <= 37.2 + 1e-9; t += 0.1) ticks.push(Number(t.toFixed(1)));
-    return ticks;
-  }, [tempMin, tempMax, tempRange]);
-
-  const findRange = useCallback((scrollLeft, viewportW) => {
-    const xs = xsRef.current;
-    if (!xs.length) return { start: 0, end: -1 };
-    const overscan = viewportW * 1.5;
-    const minX = scrollLeft - overscan;
-    const maxX = scrollLeft + viewportW + overscan;
-
-    let lo = 0;
-    let hi = xs.length - 1;
-    while (lo < hi) {
-      const mid = (lo + hi) >> 1;
-      if (xs[mid] < minX) lo = mid + 1;
-      else hi = mid;
-    }
-    const start = Math.max(0, lo - 1);
-
-    lo = 0;
-    hi = xs.length - 1;
-    while (lo < hi) {
-      const mid = ((lo + hi) >> 1) + 1;
-      if (xs[mid] > maxX) hi = mid - 1;
-      else lo = mid;
-    }
-    const end = Math.min(xs.length - 1, lo + 1);
-    return { start, end };
-  }, []);
+  }, [allDataPoints, getY]);
 
   const draw = useCallback(() => {
     const canvas = canvasRef.current;
@@ -196,8 +89,8 @@ const FertilityChartCanvas = ({
     ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
     ctx.clearRect(0, 0, viewportW, viewportH);
 
-    visibleRef.current = findRange(scrollLeft, viewportW);
-    const { start, end } = visibleRef.current;
+    const start = Number.isInteger(visibleRange?.startIndex) ? visibleRange.startIndex : 0;
+    const end = Number.isInteger(visibleRange?.endIndex) ? visibleRange.endIndex : allDataPoints.length - 1;
 
     ctx.save();
     ctx.translate(-scrollLeft, -scrollTop);
@@ -209,49 +102,39 @@ const FertilityChartCanvas = ({
     const chartAreaHeight = Math.max(chartHeight - padding.top - padding.bottom, 0);
     const perfMode = allDataPoints.length > 60 || isScrolling;
 
-    // Fondo suave (como el SVG)
     const bgGrad = ctx.createLinearGradient(0, padding.top, 0, padding.top + chartAreaHeight);
-    bgGrad.addColorStop(0, '#fffbfc');
-    bgGrad.addColorStop(0.5, '#fff5f7');
-    bgGrad.addColorStop(1, '#fff1f3');
+    theme.bgGradient.forEach((stop) => bgGrad.addColorStop(Number(stop.offset.replace('%', '')) / 100, stop.color));
     ctx.fillStyle = bgGrad;
     ctx.fillRect(padding.left, padding.top, plotW, chartAreaHeight);
 
-    // "Tarjeta" blanca con borde rosado y sombra suave (parecido al SVG)
     ctx.save();
-    ctx.shadowColor = perfMode ? 'transparent' : 'rgba(244, 114, 182, 0.10)';
+    ctx.shadowColor = perfMode ? 'transparent' : theme.card.shadowRGBA;
     ctx.shadowBlur = perfMode ? 0 : 12;
     ctx.shadowOffsetY = perfMode ? 0 : 4;
-    ctx.fillStyle = '#ffffff';
+    ctx.fillStyle = theme.card.fill;
     buildRoundRectPath(ctx, padding.left, padding.top, plotW, chartAreaHeight, 12);
     ctx.fill();
     ctx.restore();
-    ctx.save();
-    ctx.strokeStyle = 'rgba(244, 114, 182, 0.20)';
+
+    ctx.strokeStyle = theme.card.border;
     ctx.lineWidth = 1;
     buildRoundRectPath(ctx, padding.left, padding.top, plotW, chartAreaHeight, 12);
     ctx.stroke();
-    ctx.restore();
 
     const dataGrad = ctx.createLinearGradient(0, graphBottomY, 0, graphBottomY + rowsZoneHeight);
-    dataGrad.addColorStop(0, '#fff7fb');
-    dataGrad.addColorStop(0.5, '#ffe4f0');
-    dataGrad.addColorStop(1, '#fff7fb');
+    theme.dataZoneGradient.forEach((stop) => dataGrad.addColorStop(Number(stop.offset.replace('%', '')) / 100, stop.color));
     ctx.fillStyle = dataGrad;
     ctx.fillRect(padding.left, graphBottomY, plotW, rowsZoneHeight);
 
-    // Bandas de interpretación (colores más parecidos al SVG)
     if (showInterpretation && Array.isArray(interpretationSegments)) {
       interpretationSegments.forEach((segment) => {
         const { x, width } = segment.bounds || {};
         if (!Number.isFinite(x) || !Number.isFinite(width) || width <= 0) return;
         const grad = ctx.createLinearGradient(0, padding.top + chartAreaHeight * 0.5, 0, graphBottomY);
-        let c = 'rgba(203, 213, 225, 0.20)'; // nodata/fallback
-        if (segment.phase === 'relativeInfertile') c = 'rgba(16, 185, 129, 0.16)'; // verde suave
-        if (segment.phase === 'fertile') c = 'rgba(244, 114, 182, 0.22)'; // rosa
-        if (segment.phase === 'postOvulatory') c = segment.status === 'pending'
-          ? 'rgba(147, 197, 253, 0.24)' // azul claro
-          : 'rgba(59, 130, 246, 0.26)'; // azul más intenso
+        let c = 'rgba(203, 213, 225, 0.20)';
+        if (segment.phase === 'relativeInfertile') c = 'rgba(16, 185, 129, 0.16)';
+        if (segment.phase === 'fertile') c = 'rgba(244, 114, 182, 0.22)';
+        if (segment.phase === 'postOvulatory') c = segment.status === 'pending' ? 'rgba(147, 197, 253, 0.24)' : 'rgba(59, 130, 246, 0.26)';
         grad.addColorStop(0, 'rgba(255,255,255,0)');
         grad.addColorStop(1, c);
         ctx.fillStyle = grad;
@@ -262,7 +145,7 @@ const FertilityChartCanvas = ({
     tempTicks.forEach((temp) => {
       const y = getY(temp);
       const major = temp.toFixed(1).endsWith('.0') || temp.toFixed(1).endsWith('.5');
-      ctx.strokeStyle = major ? '#f9a8d4' : '#fce7f3';
+      ctx.strokeStyle = major ? theme.grid.major : theme.grid.minor;
       ctx.lineWidth = major ? 1.5 : 1;
       ctx.setLineDash(major ? [] : [4, 4]);
       ctx.beginPath();
@@ -270,17 +153,13 @@ const FertilityChartCanvas = ({
       ctx.lineTo(chartWidth - padding.right, y);
       ctx.stroke();
       ctx.setLineDash([]);
-
-      // Labels SOLO en major (evita el duplicado y queda más limpio)
       if (major) {
         const label = temp.toFixed(1);
-        ctx.fillStyle = '#be185d';
-        ctx.font = `700 ${responsiveFontSize(1)}px -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif`;
+        ctx.fillStyle = theme.text.axisMajor;
+        ctx.font = `700 ${responsiveFontSize(1)}px ${FONT_FAMILY}`;
         ctx.textBaseline = 'middle';
-
         ctx.textAlign = 'right';
         ctx.fillText(label, padding.left - responsiveFontSize(0.9), y);
-
         ctx.textAlign = 'left';
         ctx.fillText(label, chartWidth - padding.right + responsiveFontSize(0.9), y);
       }
@@ -288,7 +167,7 @@ const FertilityChartCanvas = ({
 
     for (let i = start; i <= end; i += 1) {
       const x = xsRef.current[i];
-      ctx.strokeStyle = '#fce7f3';
+      ctx.strokeStyle = theme.grid.vertical;
       ctx.lineWidth = 1;
       ctx.beginPath();
       ctx.moveTo(x, padding.top);
@@ -300,10 +179,7 @@ const FertilityChartCanvas = ({
     const x0 = xsRef.current[Math.max(0, start)] ?? padding.left;
     const x1 = xsRef.current[Math.min(xsRef.current.length - 1, end)] ?? (chartWidth - padding.right);
     const lineGrad = ctx.createLinearGradient(x0, 0, x1, 0);
-    lineGrad.addColorStop(0, '#f472b6');
-    lineGrad.addColorStop(0.5, '#ec4899');
-    lineGrad.addColorStop(1, '#be185d');
-
+    theme.tempLineGradient.forEach((stop) => lineGrad.addColorStop(Number(stop.offset.replace('%', '')) / 100, stop.color));
     ctx.strokeStyle = lineGrad;
     ctx.lineJoin = 'round';
     ctx.lineCap = 'round';
@@ -312,219 +188,37 @@ const FertilityChartCanvas = ({
     for (let i = Math.max(0, start - 1); i <= Math.min(ys.length - 1, end + 1); i += 1) {
       const y = ys[i];
       const x = xsRef.current[i];
-      if (y == null || !Number.isFinite(y)) {
-        drawing = false;
-        continue;
-      }
-      if (!drawing) {
-        ctx.moveTo(x, y);
-        drawing = true;
-      } else {
-        ctx.lineTo(x, y);
-      }
+      if (y == null || !Number.isFinite(y)) { drawing = false; continue; }
+      if (!drawing) { ctx.moveTo(x, y); drawing = true; } else ctx.lineTo(x, y);
     }
-    // Glow (como el SVG): doble trazo
-    ctx.save();
-    ctx.globalAlpha = 0.35;
-    ctx.lineWidth = 6;
-    ctx.stroke();
-    ctx.restore();
-    ctx.lineWidth = 3;
-    ctx.stroke();
+    ctx.save(); ctx.globalAlpha = 0.35; ctx.lineWidth = 6; ctx.stroke(); ctx.restore();
+    ctx.lineWidth = 3; ctx.stroke();
 
     for (let i = start; i <= end; i += 1) {
-      const y = ys[i];
-      if (y == null || !Number.isFinite(y)) continue;
+      const y = ys[i]; if (y == null || !Number.isFinite(y)) continue;
       const x = xsRef.current[i];
       const isToday = Number.isInteger(todayIndex) && i === todayIndex;
-      // Gradiente radial del punto (similar al SVG)
       const g = ctx.createRadialGradient(x - 2, y - 2, 1, x, y, 5);
-      g.addColorStop(0, '#FDF2F8');
-      g.addColorStop(0.55, '#F9A8D4');
-      g.addColorStop(1, '#EC4899');
+      theme.tempPointRadialGradient.forEach((stop) => g.addColorStop(Number(stop.offset.replace('%', '')) / 100, stop.color));
       ctx.fillStyle = g;
-      ctx.strokeStyle = isToday ? '#be185d' : '#E91E63';
+      ctx.strokeStyle = isToday ? theme.misc.today : theme.tempLineGradient[2].color;
       ctx.lineWidth = 2;
-      ctx.beginPath();
-      ctx.arc(x, y, 4, 0, Math.PI * 2);
-      ctx.fill();
-      ctx.stroke();
-      // Centro brillante
+      ctx.beginPath(); ctx.arc(x, y, 4, 0, Math.PI * 2); ctx.fill(); ctx.stroke();
       ctx.fillStyle = 'rgba(255,255,255,0.9)';
-      ctx.beginPath();
-      ctx.arc(x, y, 1.2, 0, Math.PI * 2);
-      ctx.fill();
-    }
-
-    const obsRowIndex = isFullScreen ? 9 : 7.5;
-    const halfBlock = isFullScreen ? 1 : 0.75;
-    const rowH = Math.max(textRowHeight, Math.floor(rowsZoneHeight / (obsRowIndex + halfBlock)));
-    const dateRowY = graphBottomY + rowH * 1;
-    const cycleDayRowY = graphBottomY + rowH * 2;
-    const symbolRowY = graphBottomY + rowH * 3;
-    const mucusSensationRowY = graphBottomY + rowH * (isFullScreen ? 5 : 4.5);
-    const mucusAppearanceRowY = graphBottomY + rowH * (isFullScreen ? 7 : 6);
-    const observationsRowY = graphBottomY + rowH * (isFullScreen ? 9 : 7.5);
-    const relationsRowY = showRelationsRow ? observationsRowY + rowH * (isFullScreen ? 2 : 1.5) : null;
-    const dayW = xsRef.current.length > 1 ? Math.abs(xsRef.current[1] - xsRef.current[0]) : Math.max(8, (chartWidth - padding.left - padding.right) / Math.max(allDataPoints.length, 1));
-    const availableTextWidth = Math.max(0, dayW - Math.min(12, Math.max(4, dayW * 0.12)) * 2);
-    const rowLineHeight = responsiveFontSize(0.95);
-
-    for (let row = 1; row <= 9; row += 1) {
-      const y = graphBottomY + rowH * row - rowH * 0.5;
-      ctx.strokeStyle = 'rgba(244, 114, 182, 0.12)';
-      ctx.lineWidth = 1;
-      ctx.beginPath();
-      ctx.moveTo(padding.left, y);
-      ctx.lineTo(chartWidth - padding.right, y);
-      ctx.stroke();
-    }
-    const labelStep = getLabelStep({ totalPoints: allDataPoints.length, getX, responsiveFontSize, data: allDataPoints, ctx });
-
-    for (let i = start; i <= end; i += 1) {
-      const point = allDataPoints[i];
-      if (!point) continue;
-      const x = xsRef.current[i];
-      if (i % labelStep === 0 || i === allDataPoints.length - 1) {
-        ctx.fillStyle = '#60666f';
-        ctx.textAlign = 'center';
-        ctx.textBaseline = 'middle';
-        ctx.font = `900 ${responsiveFontSize(1.05)}px -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif`;
-        ctx.fillText(compactDate(point.date), x, dateRowY);
-        ctx.font = `900 ${responsiveFontSize(1)}px -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif`;
-        ctx.fillText(String(point.cycleDay ?? ''), x, cycleDayRowY);
-      }
-
-      const symbolInfo = getSymbolAppearance(point.fertility_symbol);
-      const isFuture = point.isoDate
-        ? isAfter(startOfDay(parseISO(point.isoDate)), startOfDay(new Date()))
-        : false;
-      if (symbolInfo.value !== 'none') {
-        const palette = getSymbolColorPalette(symbolInfo.value);
-        const fill = palette.main || '#f9a8d4';
-        const border = palette.border && palette.border !== 'none' ? palette.border : null;
-        const rectX = x - 10;
-        const rectY = symbolRowY - 12;
-        const rectW = 20;
-        const rectH = 14;
-        const r = 3;
-
-        ctx.save();
-        if (symbolInfo.pattern === 'spotting-pattern') {
-          if (!spottingPatternRef.current) {
-            const patternCanvas = document.createElement('canvas');
-            patternCanvas.width = 6;
-            patternCanvas.height = 6;
-            const pctx = patternCanvas.getContext('2d');
-            if (pctx) {
-              pctx.fillStyle = '#fb7185';
-              pctx.fillRect(0, 0, 6, 6);
-              pctx.fillStyle = 'rgba(255,255,255,0.85)';
-              pctx.beginPath();
-              pctx.arc(3, 3, 1.5, 0, Math.PI * 2);
-              pctx.fill();
-              spottingPatternRef.current = ctx.createPattern(patternCanvas, 'repeat');
-            }
-          }
-          ctx.fillStyle = spottingPatternRef.current || fill;
-        } else {
-          ctx.fillStyle = fill;
-        }
-        buildRoundRectPath(ctx, rectX, rectY, rectW, rectH, r);
-        ctx.fill();
-        if (border) {
-          ctx.strokeStyle = border;
-          ctx.lineWidth = (symbolInfo.value === 'white') ? 1.6 : 1;
-          buildRoundRectPath(ctx, rectX, rectY, rectW, rectH, r);
-          ctx.stroke();
-        }
-        ctx.restore();
-      }
-      const peakStatus = point.peakStatus ? String(point.peakStatus).toUpperCase() : null;
-      if (peakStatus) {
-        ctx.fillStyle = peakStatus === 'P' || peakStatus === 'X' ? '#ec4899' : '#7f1d1d';
-        ctx.font = `800 ${responsiveFontSize(peakStatus === 'P' || peakStatus === 'X' ? 1.35 : 1.1)}px ${DEFAULT_TEXT_FONT_FAMILY}`;
-        ctx.fillText(peakStatus === 'P' || peakStatus === 'X' ? '✖' : peakStatus, x, symbolRowY - 2);
-      }
-      
-      const sensText = isFullScreen ? limitWords(point.mucus_sensation, 2, isFuture ? '' : '–') : (point.mucus_sensation || (isFuture ? '' : '–'));
-      const aparText = isFullScreen ? limitWords(point.mucus_appearance, 2, isFuture ? '' : '–') : (point.mucus_appearance || (isFuture ? '' : '–'));
-      const obsText = isFullScreen ? limitWords(point.observations, 2, '') : (point.observations || '');
-      const layoutFor = (field, text, baseSize, smallSize, fallback) => {
-        const key = `${i}-${field}-${availableTextWidth}-${baseSize}-${smallSize}-${text || ''}`;
-        const found = textLayoutCacheRef.current.get(key);
-        if (found) return found;
-        ctx.font = `700 ${baseSize}px ${DEFAULT_TEXT_FONT_FAMILY}`;
-        const base = splitTextLinesByWidth(ctx, text, { maxWidth: availableTextWidth, maxLines: 3, fontSize: baseSize, fallback });
-        const resolved = base[2]
-          ? (() => {
-            ctx.font = `700 ${smallSize}px ${DEFAULT_TEXT_FONT_FAMILY}`;
-            return { lines: splitTextLinesByWidth(ctx, text, { maxWidth: availableTextWidth, maxLines: 3, fontSize: smallSize, fallback }), fontSize: smallSize };
-          })()
-          : { lines: base, fontSize: baseSize };
-        textLayoutCacheRef.current.set(key, resolved);
-        return resolved;
-      };
-      const sens = layoutFor('sens', sensText, responsiveFontSize(0.9), responsiveFontSize(0.8), isFuture ? '' : '–');
-      const apar = layoutFor('apar', aparText, responsiveFontSize(0.9), responsiveFontSize(0.8), isFuture ? '' : '–');
-      const obs = layoutFor('obs', obsText, responsiveFontSize(0.9), responsiveFontSize(0.8), '');
-      const drawMultiline = (lines, xPos, baseY, color, fontSize) => {
-        const count = Math.max(1, lines.filter((v) => v && String(v).trim()).length);
-        ctx.fillStyle = color;
-        ctx.font = `700 ${fontSize}px ${DEFAULT_TEXT_FONT_FAMILY}`;
-        ctx.textAlign = 'center';
-        const startY = baseY - ((count - 1) * rowLineHeight) / 2;
-        let lineIndex = 0;
-        lines.forEach((line) => {
-          if (!line) return;
-          ctx.fillText(line, xPos, startY + rowLineHeight * lineIndex);
-          lineIndex += 1;
-        });
-      };
-      drawMultiline(sens.lines, x, mucusSensationRowY, SENSATION_COLOR, sens.fontSize);
-      drawMultiline(apar.lines, x, mucusAppearanceRowY, APPEARANCE_COLOR, apar.fontSize);
-      drawMultiline(obs.lines, x, observationsRowY, OBSERVATION_COLOR, obs.fontSize);
-
-      const rawTemp = point.temperature_raw;
-      const correctedTemp = point.temperature_corrected;
-      const showCorrection = !perfMode && point.use_corrected && rawTemp != null && correctedTemp != null && Math.abs(correctedTemp - rawTemp) > 0.01;
-      if (showCorrection) {
-        const rawY = getY(rawTemp);
-        if (Number.isFinite(rawY) && Number.isFinite(y)) {
-          ctx.strokeStyle = 'rgba(148, 163, 184, 0.35)';
-          ctx.setLineDash([4, 4]);
-          ctx.beginPath();
-          ctx.moveTo(x, rawY);
-          ctx.lineTo(x, y);
-          ctx.stroke();
-          ctx.setLineDash([]);
-          ctx.fillStyle = 'rgba(226, 232, 240, 0.6)';
-          ctx.strokeStyle = 'rgba(148, 163, 184, 0.5)';
-          ctx.beginPath();
-          ctx.arc(x, rawY, 3, 0, Math.PI * 2);
-          ctx.fill();
-          ctx.stroke();
-        }
-      }
-      if (showRelationsRow && relationsRowY != null && point.hasRelations) {
-        ctx.fillStyle = '#be123c';
-        ctx.font = `700 ${responsiveFontSize(1.2)}px ${DEFAULT_TEXT_FONT_FAMILY}`;
-        ctx.fillText('♥', x, relationsRowY);
-      }
+      ctx.beginPath(); ctx.arc(x, y, 1.2, 0, Math.PI * 2); ctx.fill();
     }
 
     if (showInterpretation && shouldRenderBaseline && Number.isFinite(baselineY)) {
-      ctx.strokeStyle = baselineStroke || '#F59E0B';
+      ctx.strokeStyle = baselineStroke || theme.baseline.strokeDefault;
       ctx.lineWidth = baselineWidth || 3;
-      ctx.globalAlpha = Number.isFinite(baselineOpacity) ? baselineOpacity : 1;
-      const dashList = typeof baselineDash === 'string' ? baselineDash.split(/\s+/).map(Number).filter(Number.isFinite) : [];
+      ctx.globalAlpha = Number.isFinite(baselineOpacity) ? baselineOpacity : theme.baseline.opacityDefault;
+      const dashList = typeof baselineDash === 'string' ? baselineDash.split(/\s+/).map(Number).filter(Number.isFinite) : theme.baseline.dashDefault.split(/\s+/).map(Number);
       ctx.setLineDash(dashList);
       ctx.beginPath();
       ctx.moveTo(baselineStartX, baselineY);
       ctx.lineTo(baselineEndX, baselineY);
       ctx.stroke();
-      ctx.setLineDash([]);
-      ctx.globalAlpha = 1;
+      ctx.setLineDash([]); ctx.globalAlpha = 1;
     }
 
     if (activeIndex != null && xsRef.current[activeIndex] != null) {
@@ -533,42 +227,30 @@ const FertilityChartCanvas = ({
       const next = activeIndex < xsRef.current.length - 1 ? xsRef.current[activeIndex + 1] : x;
       const fallback = Math.max((chartWidth - padding.left - padding.right) / Math.max(allDataPoints.length, 1), 0);
       const dayWidth = Math.max(((next != null && prev != null ? next - prev : 0) || fallback), fallback, 0);
-      ctx.strokeStyle = 'rgba(235, 171, 204,0.15)';
+      ctx.strokeStyle = theme.highlight.strokeTop;
       ctx.lineWidth = Math.max(2, dayWidth * 0.14);
-      ctx.beginPath();
-      ctx.moveTo(x, 0);
-      ctx.lineTo(x, graphBottomY);
-      ctx.stroke();
-      ctx.strokeStyle = 'rgba(235, 171, 204,0.32)';
+      ctx.beginPath(); ctx.moveTo(x, 0); ctx.lineTo(x, graphBottomY); ctx.stroke();
+      ctx.strokeStyle = theme.highlight.strokeBottom;
       ctx.lineWidth = Math.max(4, dayWidth * 0.5);
-      ctx.beginPath();
-      ctx.moveTo(x, graphBottomY);
-      ctx.lineTo(x, chartHeight);
-      ctx.stroke();
+      ctx.beginPath(); ctx.moveTo(x, graphBottomY); ctx.lineTo(x, chartHeight); ctx.stroke();
     }
 
-    if (!showLeftLegend) {
-      ctx.fillStyle = '#be185d';
-      ctx.font = `800 ${responsiveFontSize(1.4)}px ${DEFAULT_TEXT_FONT_FAMILY}`;
+    if (!showLegend) {
+      ctx.fillStyle = theme.text.axisMajor;
+      ctx.font = `800 ${responsiveFontSize(1.4)}px ${FONT_FAMILY}`;
       ctx.textAlign = 'center';
       ctx.fillText('°C', padding.left + responsiveFontSize(1.2), padding.top + responsiveFontSize(1.5));
     }
 
     ctx.restore();
-  }, [chartRef, findRange, chartWidth, padding, chartHeight, graphBottomY, rowsZoneHeight, showInterpretation, interpretationSegments, tempTicks, getY, responsiveFontSize, textRowHeight, allDataPoints, getX, todayIndex, shouldRenderBaseline, baselineY, baselineStartX, baselineEndX, baselineStroke, baselineDash, baselineOpacity, baselineWidth, activeIndex, isFullScreen, showRelationsRow, isScrolling, showLeftLegend]);
+  }, [activeIndex, allDataPoints.length, baselineDash, baselineEndX, baselineOpacity, baselineStartX, baselineStroke, baselineWidth, chartHeight, chartRef, chartWidth, getY, graphBottomY, handlePointInteraction, interpretationSegments, isScrolling, padding, responsiveFontSize, rowsZoneHeight, shouldRenderBaseline, showInterpretation, showLegend, tempTicks, theme, todayIndex, visibleRange]);
 
   const scheduleDraw = useCallback(() => {
     if (rafRef.current) return;
-    rafRef.current = window.requestAnimationFrame(() => {
-      rafRef.current = null;
-      draw();
-    });
+    rafRef.current = window.requestAnimationFrame(() => { rafRef.current = null; draw(); });
   }, [draw]);
 
-  useEffect(() => {
-    scheduleDraw();
-  }, [scheduleDraw]);
-
+  useEffect(() => { scheduleDraw(); }, [scheduleDraw]);
   useEffect(() => {
     const scroller = chartRef.current;
     if (!scroller) return;
@@ -580,7 +262,6 @@ const FertilityChartCanvas = ({
       scroller.removeEventListener('scroll', onScroll);
       window.removeEventListener('resize', onResize);
       if (rafRef.current) cancelAnimationFrame(rafRef.current);
-      rafRef.current = null;
     };
   }, [chartRef, scheduleDraw]);
 
@@ -589,7 +270,6 @@ const FertilityChartCanvas = ({
     if (!scroller) return null;
     const chartRect = scroller.getBoundingClientRect();
     if (!chartRect.width || !chartRect.height) return null;
-
     let localX = event.clientX - chartRect.left;
     if (isRotatedForInput) {
       const cx = chartRect.left + chartRect.width / 2;
@@ -603,58 +283,33 @@ const FertilityChartCanvas = ({
     return scroller.scrollLeft + localX;
   }, [chartRef, isRotatedForInput]);
 
-  const getClosestIndex = useCallback((worldX) => {
-    const xs = xsRef.current;
-    if (!xs.length || !Number.isFinite(worldX)) return null;
-    let low = 0;
-    let high = xs.length - 1;
-    while (low <= high) {
-      const mid = (low + high) >> 1;
-      if (xs[mid] < worldX) low = mid + 1;
-      else high = mid - 1;
-    }
-    const right = Math.min(Math.max(low, 0), xs.length - 1);
-    const left = Math.max(right - 1, 0);
-    return Math.abs(xs[left] - worldX) <= Math.abs(xs[right] - worldX) ? left : right;
-  }, []);
-
-  const onPointerDown = useCallback((event) => {
-    pointerStateRef.current = {
-      pointerId: event.pointerId,
-      startX: event.clientX,
-      startY: event.clientY,
-      moved: false,
-    };
-  }, []);
-
+  const onPointerDown = useCallback((event) => { pointerStateRef.current = { pointerId: event.pointerId, startX: event.clientX, startY: event.clientY, moved: false }; }, []);
   const onPointerMove = useCallback((event) => {
     const state = pointerStateRef.current;
     if (!state || state.pointerId !== event.pointerId) return;
-    const dx = event.clientX - state.startX;
-    const dy = event.clientY - state.startY;
-    if (Math.hypot(dx, dy) > 8) {
-      state.moved = true;
-    }
+    if (Math.hypot(event.clientX - state.startX, event.clientY - state.startY) > 8) state.moved = true;
   }, []);
-
   const onPointerUp = useCallback((event) => {
     const state = pointerStateRef.current;
     pointerStateRef.current = null;
-    if (!state || state.pointerId !== event.pointerId || state.moved) return;
-    if (!allDataPoints.length) return;
-
+    if (!state || state.pointerId !== event.pointerId || state.moved || !allDataPoints.length) return;
     const worldX = getWorldX(event);
-    const index = getClosestIndex(worldX);
-    if (index == null) return;
-
+    if (!Number.isFinite(worldX)) return;
+    const xs = xsRef.current;
+    let low = 0; let high = xs.length - 1;
+    while (low <= high) {
+      const mid = (low + high) >> 1;
+      if (xs[mid] < worldX) low = mid + 1; else high = mid - 1;
+    }
+    const right = Math.min(Math.max(low, 0), xs.length - 1);
+    const left = Math.max(right - 1, 0);
+    const index = Math.abs(xs[left] - worldX) <= Math.abs(xs[right] - worldX) ? left : right;
     const point = allDataPoints[index];
     if (!point) return;
-    const isFuture = point.isoDate
-      ? isAfter(startOfDay(parseISO(point.isoDate)), startOfDay(new Date()))
-      : false;
+    const isFuture = point.isoDate ? isAfter(startOfDay(parseISO(point.isoDate)), startOfDay(new Date())) : false;
     if (isFuture) return;
     handlePointInteraction(point, index, event);
-  }, [allDataPoints, getClosestIndex, getWorldX, handlePointInteraction]);
+  }, [allDataPoints, getWorldX, handlePointInteraction]);
 
   return (
     <div style={{ width: chartWidth, height: scrollableContentHeight, position: 'relative' }}>

--- a/src/components/chartElements/ChartAxes.jsx
+++ b/src/components/chartElements/ChartAxes.jsx
@@ -1,11 +1,11 @@
-// Description: This component renders the axes and ticks for a temperature chart.
 import React from 'react';
 import { motion } from 'framer-motion';
+import { getTempTicks } from '@/components/chartElements/chartTicks';
+import { THEME, FONT_FAMILY } from '@/components/chartElements/chartTheme';
 
 const ChartAxes = ({
   padding,
   chartWidth,
-  chartHeight,
   tempMin,
   tempMax,
   tempRange,
@@ -14,275 +14,55 @@ const ChartAxes = ({
   allDataPoints = [],
   visibleRange = null,
   responsiveFontSize,
-  isFullScreen,
   showLeftLabels = false,
   reduceMotion = false,
   isScrolling = false,
   graphBottomY,
   chartAreaHeight,
   rowsZoneHeight,
+  ids,
+  theme = THEME,
 }) => {
-  const itemVariants = {
-    hidden: { opacity: 0, y: 20 },
-    visible: { 
-      opacity: 1, 
-      y: 0,
-      transition: { duration: 0.3, ease: "easeOut" }
-    }
-  };
-
-  // build ticks every 0.1° up to 2.5° range, else every 0.5°
-  const tempTicks = [];
-  if (tempRange > 0) {
-    const tickIncrement = tempRange <= 2.5 ? 0.1 : 0.5;
-    for (let t = tempMin; t <= tempMax + 1e-9; t += tickIncrement) {
-      tempTicks.push(parseFloat(t.toFixed(1)));
-    }
-  } else {
-    for (let t = 35.8; t <= 37.2 + 1e-9; t += 0.1) {
-      tempTicks.push(parseFloat(t.toFixed(1)));
-    }
-  }
-
+  const itemVariants = { hidden: { opacity: 0, y: 20 }, visible: { opacity: 1, y: 0, transition: { duration: 0.3, ease: 'easeOut' } } };
+  const tempTicks = getTempTicks({ tempMin, tempMax, tempRange });
   const totalPoints = allDataPoints.length;
-  const isLongCycle = totalPoints > 60;
-  const perfMode = isLongCycle || isScrolling;
+  const perfMode = totalPoints > 60 || isScrolling;
   const G = reduceMotion || perfMode ? 'g' : motion.g;
   const rangeStart = Number.isInteger(visibleRange?.startIndex) ? visibleRange.startIndex : 0;
-  const rangeEnd = Number.isInteger(visibleRange?.endIndex)
-    ? visibleRange.endIndex
-    : Math.max(totalPoints - 1, 0);
+  const rangeEnd = Number.isInteger(visibleRange?.endIndex) ? visibleRange.endIndex : Math.max(totalPoints - 1, 0);
   const startIndex = totalPoints ? Math.max(0, Math.min(totalPoints - 1, rangeStart)) : 0;
   const endIndex = totalPoints ? Math.max(startIndex, Math.min(totalPoints - 1, rangeEnd)) : -1;
 
   return (
-    <>
+    <g pointerEvents="none">
+      <rect x={padding.left} y={padding.top} width={chartWidth - padding.left - padding.right} height={chartAreaHeight} fill={`url(#${ids.bgGradientId})`} rx={12} style={{ filter: `drop-shadow(0 4px 12px ${theme.card.shadowRGBA})` }} />
+      <rect x={padding.left} y={padding.top} width={chartWidth - padding.left - padding.right} height={chartAreaHeight} fill={theme.card.fill} stroke={`url(#${ids.tempLineGradientId})`} strokeWidth="1" strokeOpacity="0.2" rx="12" style={{ filter: `url(#${ids.softShadowFilterId})` }} />
+      <rect x={padding.left} y={graphBottomY} width={chartWidth - padding.left - padding.right} height={rowsZoneHeight} fill={`url(#${ids.dataZoneGradientId})`} rx="8" style={{ filter: 'drop-shadow(0 -1px 2px rgba(244, 114, 182, 0.05))' }} />
 
-      {/* Definiciones mejoradas con gradientes inspirados en la dashboard */}
-      <defs>
-        <linearGradient id="bgGradientChart" x1="0%" y1="0%" x2="0%" y2="100%">
-          <stop offset="0%" stopColor="#fffbfc" />
-          <stop offset="50%" stopColor="#fff5f7" />
-          <stop offset="100%" stopColor="#fff1f3" />
-        </linearGradient>
-        {/* AÑADE ESTE NUEVO GRADIENTE */}
-<linearGradient id="dataZoneGradient" x1="0%" y1="0%" x2="0%" y2="100%">
-  <stop offset="0%"   stopColor="#fff7fb" />
-  <stop offset="50%"  stopColor="#ffe4f0" />
-  <stop offset="100%" stopColor="#fff7fb" />
-</linearGradient>
-
-        <linearGradient id="tempLineGradientChart" x1="0%" y1="0%" x2="100%" y2="0%">
-          <stop offset="0%" stopColor="#f472b6" />
-          <stop offset="30%" stopColor="#ec4899" />
-          <stop offset="70%" stopColor="#db2777" />
-          <stop offset="100%" stopColor="#be185d" />
-        </linearGradient>
-        
-        <filter id="softShadow">
-  <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
-  <feOffset dx="0" dy="1" result="offsetblur"/>
-  <feComponentTransfer>
-    <feFuncA type="linear" slope="0.2"/>
-  </feComponentTransfer>
-  <feMerge>
-    <feMergeNode/>
-    <feMergeNode in="SourceGraphic"/>
-  </feMerge>
-</filter>
-<filter id="pointGlow">
-  <feGaussianBlur stdDeviation="2" result="coloredBlur"/>
-  <feMerge>
-    <feMergeNode in="coloredBlur"/>
-    <feMergeNode in="SourceGraphic"/>
-  </feMerge>
-</filter>
-        
-        <filter id="textShadow" x="-50%" y="-50%" width="200%" height="200%">
-          <feDropShadow dx="0" dy="1" stdDeviation="1" floodColor="rgba(255, 255, 255, 0.8)" />
-        </filter>
-
-        {/* Patrón unificado para spotting */}
-        <pattern id="spotting-pattern-chart" patternUnits="userSpaceOnUse" width="6" height="6">
-          <rect width="6" height="6" fill="#ef4444" />
-          <circle cx="3" cy="3" r="1.5" fill="rgba(255,255,255,0.85)" />
-        </pattern>
-      </defs>
-
-      <g pointerEvents="none">
-
-      {/* Fondo con gradiente elegante inspirado en la dashboard */}
-      <rect
-        x={padding.left}
-        y={padding.top}
-        width={chartWidth - padding.left - padding.right}
-        height={chartAreaHeight}
-        fill="url(#bgGradientChart)"
-        opacity={2}
-        rx={12}
-        style={{ filter: 'drop-shadow(0 4px 12px rgba(244, 114, 182, 0.1))' }}
-      />
-{/* Fondo del área de gráfica con borde rosado sutil */}
-<rect
-  x={padding.left}
-  y={padding.top}
-  width={chartWidth - padding.left - padding.right}
-  height={chartAreaHeight}
-  fill="white"
-  stroke="url(#tempLineGradientChart)"
-  strokeWidth="1"
-  strokeOpacity="0.2"
-  rx="12"
-  style={{ filter: 'url(#softShadow)' }}
-/>
-
-{/* AÑADE ESTO AQUÍ - Fondo sutil para zona de datos inferior */}
-<rect
-  x={padding.left}
-  y={graphBottomY}
-  width={chartWidth - padding.left - padding.right}
-  height={rowsZoneHeight}
-  fill="url(#dataZoneGradient)"
-  rx="8"
-  style={{ 
-    filter: 'drop-shadow(0 -1px 2px rgba(244, 114, 182, 0.05))'
-  }}
-/>
-      {/* Líneas de cuadrícula con estilo mejorado */}
       {tempTicks.map((temp, i) => {
         const y = getY(temp);
         const isMajor = temp.toFixed(1).endsWith('.0') || temp.toFixed(1).endsWith('.5');
-        const labelText = isMajor
-          ? temp.toFixed(1)
-          : `.${temp.toFixed(1).split('.')[1]}`;
-
+        const labelText = isMajor ? temp.toFixed(1) : `.${temp.toFixed(1).split('.')[1]}`;
         return (
-          <G
-            key={`temp-tick-${i}`}
-            {...(reduceMotion || perfMode ? {} : { variants: itemVariants })}
-          >
-            {/* Líneas de cuadrícula con gradientes sutiles */}
-            <line
-              x1={padding.left}
-              y1={y}
-              x2={chartWidth - padding.right}
-              y2={y}
-              stroke={isMajor ? '#f9a8d4' : '#fce7f3'}
-              strokeWidth={isMajor ? 1.5 : 1}
-              opacity={isMajor ? 0.5 : 0.3}
-              strokeDasharray={isMajor ? '0' : '4,4'}
-              style={{ 
-                filter: isMajor && !perfMode ? 'drop-shadow(0 1px 3px rgba(244, 114, 182, 0.15))' : 'none',
-                opacity: isMajor ? 1 : 0.7
-              }}
-            />
-
-            {/* Etiquetas izquierda con diseño premium */}
-            {showLeftLabels && (
-              <text
-                x={padding.left - responsiveFontSize(1)}
-                y={y + responsiveFontSize(0.35)}
-                textAnchor="end"
-                fontSize={responsiveFontSize(isMajor ? 1.1 : 1)}
-                fontWeight={isMajor ? "700" : "600"}
-                fill={isMajor ? '#be185d' : '#db2777'}
-                opacity={isMajor ? 0.9 : 0.7}
-                style={{ 
-                  filter: perfMode ? 'none' : 'url(#textShadow)',
-                  fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif'
-                }}
-              >
-                {labelText}
-              </text>
-            )}
-
-            {/* Etiquetas derecha con diseño premium */}
-            <text
-              x={chartWidth - padding.right + responsiveFontSize(1)}
-              y={y + responsiveFontSize(0.35)}
-              textAnchor="start"
-              fontSize={responsiveFontSize(isMajor ? 1.1 : 1)}
-              fontWeight={isMajor ? "700" : "600"}
-              fill={isMajor ? '#be185d' : '#db2777'}
-              opacity={isMajor ? 0.9 : 0.7}
-              style={{ 
-                filter: perfMode ? 'none' : 'url(#textShadow)',
-                fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif'
-              }}
-            >
-              {labelText}
-            </text>
+          <G key={`temp-${i}`} {...(reduceMotion || perfMode ? {} : { variants: itemVariants })}>
+            <line x1={padding.left} y1={y} x2={chartWidth - padding.right} y2={y} stroke={isMajor ? theme.grid.major : theme.grid.minor} strokeWidth={isMajor ? 1.5 : 1} opacity={isMajor ? 1 : 0.7} strokeDasharray={isMajor ? '0' : '4,4'} />
+            {showLeftLabels && <text x={padding.left - responsiveFontSize(1)} y={y + responsiveFontSize(0.35)} textAnchor="end" fontSize={responsiveFontSize(isMajor ? 1.1 : 1)} fontWeight={isMajor ? '700' : '600'} fill={isMajor ? theme.text.axisMajor : theme.text.axisMinor} style={{ filter: perfMode ? 'none' : `url(#${ids.textShadowFilterId})`, fontFamily: FONT_FAMILY }}>{labelText}</text>}
+            <text x={chartWidth - padding.right + responsiveFontSize(1)} y={y + responsiveFontSize(0.35)} textAnchor="start" fontSize={responsiveFontSize(isMajor ? 1.1 : 1)} fontWeight={isMajor ? '700' : '600'} fill={isMajor ? theme.text.axisMajor : theme.text.axisMinor} style={{ filter: perfMode ? 'none' : `url(#${ids.textShadowFilterId})`, fontFamily: FONT_FAMILY }}>{labelText}</text>
           </G>
         );
       })}
 
-      {/* Líneas verticales de días con gradiente sutil */}
-      {totalPoints > 0 &&
-        Array.from({ length: endIndex - startIndex + 1 }, (_, offset) => {
-          const i = startIndex + offset;
-          const x = getX(i);
-          return (
-            <line
-              key={`day-grid-${i}`}
-              x1={x}
-              y1={padding.top}
-              x2={x}
-              y2={graphBottomY}
-              stroke="#fce7f3"
-              strokeWidth="1"
-              opacity="0.6"
-              style={{
-                filter: perfMode ? 'none' : 'drop-shadow(0 0 1px rgba(244, 114, 182, 0.05))',
-              }}
-            />
-          );
-        })}
+      {totalPoints > 0 && Array.from({ length: endIndex - startIndex + 1 }, (_, o) => {
+        const i = startIndex + o;
+        const x = getX(i);
+        return <line key={`v-${i}`} x1={x} y1={padding.top} x2={x} y2={graphBottomY} stroke={theme.grid.vertical} strokeWidth="1" opacity="0.6" />;
+      })}
 
-      {/* Bordes del área del gráfico con estilo premium */}
-      <rect
-          x={padding.left}
-          y={padding.top}
-          width={chartWidth - padding.left - padding.right}
-          height={chartAreaHeight}
-          fill="none"
-          stroke="url(#tempLineGradientChart)"
-          strokeWidth="2"
-          strokeOpacity="0.4"
-          rx="12"
-        />
-        <rect
-          x={padding.left + 1}
-          y={padding.top + 1}
-          width={chartWidth - padding.left - padding.right - 2}
-          height={chartAreaHeight - 2}
-          fill="none"
-          stroke="white"
-          strokeWidth="0.5"
-          rx="11"
-          opacity="0.9"
-        />
-          {/* Unidad °C con diseño premium similar a la dashboard */}
-      {showLeftLabels && (
-        <G {...(reduceMotion || perfMode ? {} : { variants: itemVariants })}>
+      <rect x={padding.left} y={padding.top} width={chartWidth - padding.left - padding.right} height={chartAreaHeight} fill="none" stroke={`url(#${ids.tempLineGradientId})`} strokeWidth="2" strokeOpacity="0.4" rx="12" />
+      <rect x={padding.left + 1} y={padding.top + 1} width={chartWidth - padding.left - padding.right - 2} height={chartAreaHeight - 2} fill="none" stroke="white" strokeWidth="0.5" rx="11" opacity="0.9" />
 
-          <text
-            x={padding.left + responsiveFontSize(1.2)}
-            y={padding.top + responsiveFontSize(1.5)}
-            textAnchor="middle"
-            fontSize={responsiveFontSize(1.4)}
-            fontWeight="800"
-            fill="#be185d"
-            style={{ 
-              filter: perfMode ? 'none' : 'url(#textShadow)',
-              fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif'
-            }}
-          >
-            °C
-          </text>
-        </G>
-      )}
+      {showLeftLabels && <G {...(reduceMotion || perfMode ? {} : { variants: itemVariants })}><text x={padding.left + responsiveFontSize(1.2)} y={padding.top + responsiveFontSize(1.5)} textAnchor="middle" fontSize={responsiveFontSize(1.4)} fontWeight="800" fill={theme.text.axisMajor} style={{ filter: perfMode ? 'none' : `url(#${ids.textShadowFilterId})`, fontFamily: FONT_FAMILY }}>°C</text></G>}
     </g>
-    </>
   );
 };
 

--- a/src/components/chartElements/ChartLeftLegend.jsx
+++ b/src/components/chartElements/ChartLeftLegend.jsx
@@ -1,12 +1,9 @@
-import React from 'react';
-import { useMemo } from 'react';
+import React, { useMemo } from 'react';
 import { Heart } from 'lucide-react';
 import { motion } from 'framer-motion';
-
-// Colores consistentes con la dashboard
-const SENSATION_COLOR = 'var(--color-sensacion-fuerte)';
-const APPEARANCE_COLOR = 'var(--color-apariencia-fuerte)';
-const OBSERVATION_COLOR = 'var(--color-observaciones-fuerte)';
+import { getTempTicks } from '@/components/chartElements/chartTicks';
+import { getRowMetrics } from '@/components/chartElements/chartLayout';
+import { THEME, FONT_FAMILY } from '@/components/chartElements/chartTheme';
 
 const ChartLeftLegend = ({
   padding,
@@ -22,165 +19,56 @@ const ChartLeftLegend = ({
   graphBottomY,
   rowsZoneHeight,
   showRelationsRow = false,
+  theme = THEME,
+  ids,
 }) => {
-  const itemVariants = {
-    hidden: { opacity: 0, y: 20 },
-    visible: { 
-      opacity: 1, 
-      y: 0,
-      transition: { duration: 0.4, ease: "easeOut" }
-    }
-  };
+  const tempTicks = getTempTicks({ tempMin, tempMax, tempRange });
+  const { rowsTopY, rowH, obsRowIndex } = getRowMetrics({ graphBottomY, isFullScreen, rowsZoneHeight, textRowHeight, showRelationsRow });
+  const relationsRowIndex = showRelationsRow ? obsRowIndex + (isFullScreen ? 2 : 1.5) : null;
 
-  const tempTicks = [];
-  if (tempRange > 0) {
-    const tickIncrement = tempRange <= 2.5 ? 0.1 : 0.5;
-    for (let t = tempMin; t <= tempMax + 1e-9; t += tickIncrement) {
-      tempTicks.push(parseFloat(t.toFixed(1)));
-    }
-  } else {
-    for (let t = 35.8; t <= 37.2 + 1e-9; t += 0.1) {
-      tempTicks.push(parseFloat(t.toFixed(1)));
-    }
-  }
-
-  // Ancla y estirado igual que las filas del chart
-  const rowsTopY = graphBottomY;
-  const obsRowIndex = isFullScreen ? 9 : 7.5;
-  const halfBlock = isFullScreen ? 1 : 0.75;
-  const relationsRowIndex = showRelationsRow
-    ? obsRowIndex + (isFullScreen ? 2 : 1.5)
-    : null;
-  const baseRowCount = obsRowIndex + halfBlock;
-  const autoRowH = Math.max(1, Math.floor(rowsZoneHeight / baseRowCount));
-  const rowH = Math.max(textRowHeight, autoRowH);
   const legendRows = useMemo(() => {
     const baseRows = [
-      { label: 'Fecha', row: 1, color: isFullScreen ? '#374151' : '#374151', icon: null },
-      { label: 'Día', row: 2, color: isFullScreen ? '#374151' : '#374151', icon: null },
-      { label: 'Símbolo', row: 3, color: isFullScreen ? '#374151' : '#374151', icon: null },
-      { label: 'Sens.', row: isFullScreen ? 5 : 4.5, color: SENSATION_COLOR, icon: { type: 'text', value: '◊' } },
-      { label: 'Apar.', row: isFullScreen ? 7 : 6, color: APPEARANCE_COLOR, icon: { type: 'text', value: '○' } },
-      { label: 'Obs.', row: isFullScreen ? 9 : 7.5, color: OBSERVATION_COLOR, icon: { type: 'text', value: '✦' } },
+      { label: 'Fecha', row: 1, color: theme.text.neutral, icon: null },
+      { label: 'Día', row: 2, color: theme.text.neutral, icon: null },
+      { label: 'Símbolo', row: 3, color: theme.text.neutral, icon: null },
+      { label: 'Sens.', row: isFullScreen ? 5 : 4.5, color: `var(${theme.rowColors.sensation.cssVar})`, icon: { type: 'text', value: '◊' } },
+      { label: 'Apar.', row: isFullScreen ? 7 : 6, color: `var(${theme.rowColors.appearance.cssVar})`, icon: { type: 'text', value: '○' } },
+      { label: 'Obs.', row: isFullScreen ? 9 : 7.5, color: `var(${theme.rowColors.observation.cssVar})`, icon: { type: 'text', value: '✦' } },
     ];
-    if (showRelationsRow && relationsRowIndex != null) {
-      baseRows.push({ label: 'RS', row: relationsRowIndex, color: '#f44336', icon: { type: 'heart' } });
-    }
+    if (showRelationsRow && relationsRowIndex != null) baseRows.push({ label: 'RS', row: relationsRowIndex, color: theme.rowColors.relations.fallback, icon: { type: 'heart' } });
     return baseRows;
-  }, [isFullScreen, relationsRowIndex, showRelationsRow]);
+  }, [isFullScreen, relationsRowIndex, showRelationsRow, theme]);
+
   const MotionGroup = reduceMotion ? 'g' : motion.g;
-  const motionGroupProps = reduceMotion ? {} : { variants: itemVariants };
   return (
-    <svg
-      width={padding.left}
-      height={chartHeight}
-      className="font-sans pointer-events-none"
-    >
-      <defs>
-        <filter id="textShadowLegend" x="-50%" y="-50%" width="200%" height="200%">
-          <feDropShadow dx="0" dy="1" stdDeviation="1" floodColor="rgba(255, 255, 255, 0.9)" />
-        </filter>
-      </defs>
-
-      {/* Fondo premium para las etiquetas de filas */}
-
-
-
-
-      {/* Etiquetas de temperatura con diseño premium */}
+    <svg width={padding.left} height={chartHeight} className="font-sans pointer-events-none">
       {tempTicks.map((temp, i) => {
         const y = getY(temp);
         const isMajor = temp.toFixed(1).endsWith('.0') || temp.toFixed(1).endsWith('.5');
-        const labelText = isMajor
-          ? temp.toFixed(1)
-          : `.${temp.toFixed(1).split('.')[1]}`;
-        
+        const labelText = isMajor ? temp.toFixed(1) : `.${temp.toFixed(1).split('.')[1]}`;
         return (
-          <MotionGroup key={`temp-tick-fixed-${i}`} {...motionGroupProps}>
-            
-            <text
-              x={padding.left - responsiveFontSize(1.2)}
-              y={y + responsiveFontSize(0.35)}
-              textAnchor="end"
-              fontSize={responsiveFontSize(isMajor ? 1.15 : 1)}
-              fontWeight={isMajor ? "800" : "700"}
-              fill={isMajor ? "#be185d" : "#db2777"}
-              opacity={isMajor ? 1 : 0.85}
-              style={{ 
-                filter: 'url(#textShadowLegend)',
-                fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif'
-              }}
-            >
-              {labelText}
-            </text>
+          <MotionGroup key={`tick-${i}`}>
+            <text x={padding.left - responsiveFontSize(1.2)} y={y + responsiveFontSize(0.35)} textAnchor="end" fontSize={responsiveFontSize(isMajor ? 1.15 : 1)} fontWeight={isMajor ? '800' : '700'} fill={isMajor ? theme.text.axisMajor : theme.text.axisMinor} opacity={isMajor ? 1 : 0.85} style={{ fontFamily: FONT_FAMILY }}>{labelText}</text>
           </MotionGroup>
         );
       })}
 
-      
-
-      {/* Etiquetas de filas con diseño mejorado */}
-      <MotionGroup {...motionGroupProps}>
+      <MotionGroup>
         {legendRows.map(({ label, row, color, icon }) => {
           const iconX = padding.left - responsiveFontSize(2.8);
           const iconY = rowsTopY + rowH * row;
           const iconSize = responsiveFontSize(0.95);
           return (
-          <g key={label}>
-            {/* Indicador visual para las categorías de datos */}
-            {icon?.type === 'text' && (
-              <text
-                x={iconX}
-                y={iconY}
-                textAnchor="middle"
-                fontSize={responsiveFontSize(0.8)}
-                fontWeight="600"
-                fill={color}
-                opacity={0.7}
-                style={{ 
-                  filter: 'url(#textShadowLegend)',
-                  fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif'
-                }}
-              >
-                {icon.value}
-              </text>
-            )}
-            {icon?.type === 'heart' && (
-              <g transform={`translate(${iconX - iconSize / 2}, ${iconY - iconSize / 2})`} opacity={0.7}>
-                <Heart
-                  width={iconSize}
-                  height={iconSize}
-                  color={color}
-                  fill={color}
-                  aria-hidden="true"
-                />
-              </g>
-            )}
-            
-            <text
-              x={padding.left - responsiveFontSize(0.8)}
-              y={rowsTopY + rowH * row}
-              textAnchor="end"
-              fontSize={responsiveFontSize(1.05)}
-              fontWeight="800"
-              fill={color}
-              style={{ 
-                filter: 'url(#textShadowLegend)',
-                fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif'
-              }}
-            >
-              {label}
-            </text>
-          </g>
-        );
+            <g key={label}>
+              {icon?.type === 'text' && <text x={iconX} y={iconY} textAnchor="middle" fontSize={responsiveFontSize(0.8)} fontWeight="600" fill={color} opacity={0.7} style={{ fontFamily: FONT_FAMILY }}>{icon.value}</text>}
+              {icon?.type === 'heart' && <g transform={`translate(${iconX - iconSize / 2}, ${iconY - iconSize / 2})`} opacity={0.7}><Heart width={iconSize} height={iconSize} color={color} fill={color} aria-hidden="true" /></g>}
+              <text x={padding.left - responsiveFontSize(0.8)} y={rowsTopY + rowH * row} textAnchor="end" fontSize={responsiveFontSize(1.05)} fontWeight="800" fill={color} style={{ fontFamily: FONT_FAMILY }}>{label}</text>
+            </g>
+          );
         })}
-        
       </MotionGroup>
-
     </svg>
-    
   );
 };
-
 
 export default ChartLeftLegend;

--- a/src/components/chartElements/ChartLine.jsx
+++ b/src/components/chartElements/ChartLine.jsx
@@ -1,16 +1,8 @@
 import React, { useMemo } from 'react';
 import { motion } from 'framer-motion';
+import { THEME } from '@/components/chartElements/chartTheme';
 
-const ChartLine = ({
-  data,
-  allDataPoints,
-  getX,
-  getY,
-  baselineY,
-  temperatureField = 'temperature',
-  reduceMotion = false,
-  connectGaps = true,
-}) => {
+const ChartLine = ({ data, allDataPoints, getX, getY, temperatureField = 'temperature', reduceMotion = false, connectGaps = true, ids, theme = THEME }) => {
   if (!data || data.length < 2) return null;
 
   const { pathD, thinPathD, hasContinuousSegment } = useMemo(() => {
@@ -19,150 +11,45 @@ const ChartLine = ({
     let lastValidIndex = null;
     const validPoints = [];
 
-  allDataPoints.forEach((point, index) => {
+    allDataPoints.forEach((point, index) => {
       const dataPoint = dataById.get(point.id);
-      if (
-        dataPoint
-        && dataPoint[temperatureField] !== null
-        && dataPoint[temperatureField] !== undefined
-        && !dataPoint.ignored
-      ) {
+      if (dataPoint && dataPoint[temperatureField] != null && !dataPoint.ignored) {
         const x = getX(index);
         const y = getY(dataPoint[temperatureField]);
         validPoints.push({ x, y });
-        if (lastValidIndex !== null && index === lastValidIndex + 1) {
-          linePath += ` L ${x} ${y}`;
-        } else {
-          linePath += `${linePath ? ' ' : ''}M ${x} ${y}`;
-        }
+        if (lastValidIndex !== null && index === lastValidIndex + 1) linePath += ` L ${x} ${y}`;
+        else linePath += `${linePath ? ' ' : ''}M ${x} ${y}`;
         lastValidIndex = index;
       }
-      });
+    });
 
-    if (validPoints.length < 2) {
-      return { pathD: '', thinPathD: '', hasContinuousSegment: false };
-    }
-
-  const nextThinPathD =
-      connectGaps && validPoints.length > 1
-        ? validPoints
-            .map(({ x, y }, idx) => `${idx === 0 ? 'M' : 'L'} ${x} ${y}`)
-            .join(' ')
-        : '';
-
-    return {
-      pathD: linePath,
-      thinPathD: nextThinPathD,
-      hasContinuousSegment: linePath.includes('L'),
-    };
+    if (validPoints.length < 2) return { pathD: '', thinPathD: '', hasContinuousSegment: false };
+    const nextThinPathD = connectGaps ? validPoints.map(({ x, y }, idx) => `${idx === 0 ? 'M' : 'L'} ${x} ${y}`).join(' ') : '';
+    return { pathD: linePath, thinPathD: nextThinPathD, hasContinuousSegment: linePath.includes('L') };
   }, [allDataPoints, data, getX, getY, temperatureField, connectGaps]);
 
   if (!pathD) return null;
 
   return (
-    <>
-      {/* Definiciones para gradientes y filtros mejorados */}
-      <defs>
-        <linearGradient id="tempLineGradientChart" x1="0%" y1="0%" x2="100%" y2="0%">
-          <stop offset="0%" stopColor="#f472b6" />
-          <stop offset="30%" stopColor="#ec4899" />
-          <stop offset="70%" stopColor="#db2777" />
-          <stop offset="100%" stopColor="#be185d" />
-        </linearGradient>
-                
-        <filter id="lineShadow" x="-50%" y="-50%" width="200%" height="200%">
-          <feDropShadow dx="0" dy="2" stdDeviation="3" floodColor="rgba(244, 114, 182, 0.4)" />
-        </filter>
-      </defs>
     <g pointerEvents="none">
+      {hasContinuousSegment && (reduceMotion ? (
+        <path d={pathD} fill="none" stroke={`url(#${ids.tempLineGlowGradientId})`} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" opacity={0.4} style={{ filter: `url(#${ids.lineGlowFilterId})` }} />
+      ) : (
+        <motion.path d={pathD} fill="none" stroke={`url(#${ids.tempLineGlowGradientId})`} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" opacity={0.4} style={{ filter: `url(#${ids.lineGlowFilterId})` }} initial={{ pathLength: 0, opacity: 0 }} animate={{ pathLength: 1, opacity: 0.4 }} transition={{ duration: 0.8, ease: 'easeInOut', delay: 0.2 }} />
+      ))}
 
-      {/* Línea de respaldo con efecto glow */}
-      {hasContinuousSegment && (
-        reduceMotion ? (
-          <path
-            d={pathD}
-            fill="none"
-            stroke="url(#tempLineGradientChartGlow)"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            opacity={0.4}
-            style={{ filter: 'url(#lineGlow)' }}
-          />
-        ) : (
-          <motion.path
-            d={pathD}
-            fill="none"
-            stroke="url(#tempLineGradientChartGlow)"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            opacity={0.4}
-            style={{ filter: 'url(#lineGlow)' }}
-            initial={{ pathLength: 0, opacity: 0 }}
-            animate={{ pathLength: 1, opacity: 0.4 }}
-            transition={{ duration: 0.8, ease: "easeInOut", delay: 0.2 }}
-          />
-        )
-      )}
+      {thinPathD && (reduceMotion ? (
+        <path d={thinPathD} fill="none" stroke={theme.misc.correctionLine} strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" opacity={0.65} />
+      ) : (
+        <motion.path d={thinPathD} fill="none" stroke={theme.misc.correctionLine} strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" opacity={0.65} initial={{ pathLength: 0, opacity: 0 }} animate={{ pathLength: 1, opacity: 0.65 }} transition={{ duration: 0.8, ease: 'easeInOut' }} />
+      ))}
 
-      {/* Línea conectando puntos no consecutivos */}
-      {thinPathD && (
-        reduceMotion ? (
-          <path
-            d={thinPathD}
-            fill="none"
-            stroke="#d587b1"
-            strokeWidth="3"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            opacity={0.65}
-          />
-        ) : (
-          <motion.path
-            d={thinPathD}
-            fill="none"
-            stroke="#d587b1"
-            strokeWidth="3"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            opacity={0.65}
-            initial={{ pathLength: 0, opacity: 0 }}
-            animate={{ pathLength: 1, opacity: 0.65 }}
-            transition={{ duration: 0.8, ease: "easeInOut" }}
-          />
-        )
-      )}
-
-      {/* Línea principal con gradiente premium */}
-      {hasContinuousSegment && (
-        reduceMotion ? (
-          <path
-            d={pathD}
-            fill="none"
-            stroke="url(#tempLineGradientChart)"
-            strokeWidth="3"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            style={{ filter: 'url(#lineShadow)' }}
-          />
-        ) : (
-          <motion.path
-            d={pathD}
-            fill="none"
-            stroke="url(#tempLineGradientChart)"
-            strokeWidth="3"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            style={{ filter: 'url(#lineShadow)' }}
-            initial={{ pathLength: 0, opacity: 0 }}
-            animate={{ pathLength: 1, opacity: 1 }}
-            transition={{ duration: 1, ease: "easeInOut", delay: 0.4 }}
-          />
-        )
-      )}
+      {hasContinuousSegment && (reduceMotion ? (
+        <path d={pathD} fill="none" stroke={`url(#${ids.tempLineGradientId})`} strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" style={{ filter: `url(#${ids.lineShadowFilterId})` }} />
+      ) : (
+        <motion.path d={pathD} fill="none" stroke={`url(#${ids.tempLineGradientId})`} strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" style={{ filter: `url(#${ids.lineShadowFilterId})` }} initial={{ pathLength: 0, opacity: 0 }} animate={{ pathLength: 1, opacity: 1 }} transition={{ duration: 1, ease: 'easeInOut', delay: 0.4 }} />
+      ))}
     </g>
-    </>
   );
 };
 

--- a/src/components/chartElements/ChartPoints.jsx
+++ b/src/components/chartElements/ChartPoints.jsx
@@ -3,34 +3,10 @@ import { Heart } from 'lucide-react';
 import { motion } from 'framer-motion';
 import { parseISO, startOfDay, isAfter, isSameDay } from 'date-fns';
 import { getSymbolAppearance, getSymbolColorPalette } from '@/config/fertilitySymbols';
-// Colores consistentes con la dashboard pero con mejor contraste para el chart
-const SENSATION_COLOR = 'var(--color-sensacion-fuerte)';
-const APPEARANCE_COLOR = 'var(--color-apariencia-fuerte)';
-const OBSERVATION_COLOR = 'var(--color-observaciones-fuerte)';
-const HEART_COLOR = '#be123c';
+import { FONT_FAMILY, THEME } from '@/components/chartElements/chartTheme';
+import { getRowMetrics, getLabelStep } from '@/components/chartElements/chartLayout';
 
-const BACKGROUND_COLOR = 'rgba(252, 231, 243, 0.40)';
-const BORDER_COLOR = 'rgba(244, 114, 182, 0.08)';
-
-const ROW_BACKGROUND_FILL_SOFT_sens = '#EFF6FF';
-const ROW_BACKGROUND_FILL_SOFT_apa = '#ECFDF5';
-const ROW_BACKGROUND_FILL_SOFT_obs = '#F5F3FF';
-const ROW_TINT_ALPHA = 0.2;
-const SENSATION_BORDER_COLOR = 'rgba(14, 165, 233, 0.18)';
-const APPEARANCE_BORDER_COLOR = 'rgba(16, 185, 129, 0.18)';
-const OBSERVATION_BORDER_COLOR = 'rgba(139, 92, 246, 0.18)';
-const ROW_SHADOW = 'drop-shadow(0 1px 2px rgba(15, 23, 42, 0.08))';
-const CORRECTION_LINE_COLOR = 'rgba(148, 163, 184, 0.35)';
-const CORRECTION_POINT_FILL = 'rgba(226, 232, 240, 0.6)';
-const CORRECTION_POINT_STROKE = 'rgba(148, 163, 184, 0.5)';
 const PEAK_EMOJI = '✖';
-const POST_PEAK_MARKER_COLOR = '#7f1d1d';
-const PEAK_EMOJI_COLOR = '#ec4899';
-const PEAK_TEXT_SHADOW = 'drop-shadow(0 2px 4px rgba(244, 114, 182, 0.35))';
-const HIGH_SEQUENCE_NUMBER_COLOR = '#be185d';
-const BASELINE_NUMBER_COLOR = '#2563eb';
-const TODAY_HIGHLIGHT_COLOR = '#be185d';
-const SYMBOL_BORDER_FALLBACK = 'rgba(244, 114, 182, 0.35)';
 
 
 /** Quita ceros iniciales a día/mes */
@@ -40,8 +16,7 @@ const compactDate = (dateStr) => {
   return `${parseInt(d, 10)}/${parseInt(m, 10)}`;
 };
 
-const DEFAULT_TEXT_FONT_FAMILY =
-  '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif';
+const DEFAULT_TEXT_FONT_FAMILY = FONT_FAMILY;
 
 const createTextMeasurer = () => {
   if (typeof document === 'undefined') {
@@ -199,6 +174,9 @@ const ChartPoints = ({
   showRelationsRow = false,
   autoLabelStep = false,
   isArchivedCycle = false,
+  ids,
+  theme = THEME,
+  renderMode = 'full',
 }) => {
   const itemVariants = {
     hidden: { opacity: 0, y: 20 },
@@ -224,28 +202,19 @@ const ChartPoints = ({
     }
   };
 
-  // --- Filas ancladas al final del área de gráfico (graphBottomY) y estiradas hasta abajo ---
-  const rowsTopY = graphBottomY; // el “techo” de las filas es justo donde acaba la gráfica
-  const obsRowIndex = isFullScreen ? 9 : 7.5;
-  const halfBlock = isFullScreen ? 1 : 0.75;
-  const relationsRowIndex = showRelationsRow
-    ? obsRowIndex + (isFullScreen ? 2 : 1.5)
-    : null;
-  const baseRowCount = obsRowIndex + halfBlock;
-  // altura ideal basada en el layout original para no comprimir filas existentes
-  const autoRowH = Math.max(1, Math.floor(rowsZoneHeight / baseRowCount));
-  // no reducimos por debajo del tamaño base (legibilidad), pero sí estiramos
-  const rowH = Math.max(textRowHeight, autoRowH);
-
-  const dateRowY = rowsTopY + rowH * 1;
-  const cycleDayRowY = rowsTopY + rowH * 2;
-  const symbolRowYBase = rowsTopY + rowH * 3;
-  const mucusSensationRowY = rowsTopY + rowH * (isFullScreen ? 5 : 4.5);
-  const mucusAppearanceRowY = rowsTopY + rowH * (isFullScreen ? 7 : 6);
-  const observationsRowY = rowsTopY + rowH * (isFullScreen ? 9 : 7.5);
-  const relationsRowY = showRelationsRow
-    ? observationsRowY + rowH * (isFullScreen ? 2 : 1.5)
-    : null;
+  const {
+    rowsTopY,
+    obsRowIndex,
+    rowH,
+    dateRowY,
+    cycleDayRowY,
+    symbolRowYBase,
+    mucusSensationRowY,
+    mucusAppearanceRowY,
+    observationsRowY,
+    relationsRowY,
+  } = getRowMetrics({ graphBottomY, isFullScreen, rowsZoneHeight, textRowHeight, showRelationsRow });
+  const relationsRowIndex = showRelationsRow ? obsRowIndex + (isFullScreen ? 2 : 1.5) : null;
 
   const totalPoints = Array.isArray(data) ? data.length : 0;
   const isLongCycle = totalPoints > 60;
@@ -277,25 +246,16 @@ const ChartPoints = ({
   const smallAppearanceFontSize = responsiveFontSize(0.8);
   const smallObservationFontSize = responsiveFontSize(0.8);
   const labelStep = useMemo(() => {
-    if (!autoLabelStep || totalPoints < 2) return 1;
-    const dayWidth = Math.abs(getX(1) - getX(0));
-    if (!Number.isFinite(dayWidth) || dayWidth <= 0) return 1;
-    const samplePoint = data?.find((entry) => entry?.date || entry?.cycleDay != null) ?? {};
-    const sampleDate = compactDate(samplePoint?.date || '00/00');
-    const sampleDay = String(samplePoint?.cycleDay ?? totalPoints ?? '');
-    const dateFontSize = responsiveFontSize(1.05);
-    const dayFontSize = responsiveFontSize(1);
-    const dateWidth = measureTextWidth(
-      sampleDate,
-      buildFontString(dateFontSize, 900, DEFAULT_TEXT_FONT_FAMILY)
-    );
-    const dayWidthText = measureTextWidth(
-      sampleDay,
-      buildFontString(dayFontSize, 900, DEFAULT_TEXT_FONT_FAMILY)
-    );
-    const minLabelWidth = Math.max(dateWidth, dayWidthText) + responsiveFontSize(0.8);
-    return Math.max(1, Math.ceil(minLabelWidth / dayWidth));
-  }, [autoLabelStep, totalPoints, getX, data, measureTextWidth, responsiveFontSize]);
+    if (!autoLabelStep) return 1;
+    return getLabelStep({
+      totalPoints,
+      getX,
+      responsiveFontSize,
+      data,
+      measureTextWidth,
+      fontFamily: DEFAULT_TEXT_FONT_FAMILY,
+    });
+  }, [autoLabelStep, totalPoints, getX, responsiveFontSize, data, measureTextWidth]);
 
   const highSequenceOrderMap = useMemo(() => {
     if (!showInterpretation) {
@@ -405,7 +365,7 @@ for (let i = orderedAscending.length - 1; i >= 0; i -= 1) {
   const rowLabelShadow = perfMode ? 'none' : 'drop-shadow(0 1px 2px rgba(255, 255, 255, 0.9))';
   const textShadowSoft = perfMode ? 'none' : 'drop-shadow(0 1px 1px rgba(255, 255, 255, 0.8))';
   const textShadowStrong = perfMode ? 'none' : 'drop-shadow(0 1px 2px rgba(255, 255, 255, 0.9))';
-  const peakShadow = perfMode ? 'none' : PEAK_TEXT_SHADOW;
+  const peakShadow = perfMode ? 'none' : 'drop-shadow(0 2px 4px rgba(244, 114, 182, 0.35))';
   const activeShadow = perfMode
     ? 'none'
     : 'drop-shadow(0 2px 4px rgba(244, 114, 182, 0.25))';
@@ -474,62 +434,24 @@ for (let i = orderedAscending.length - 1; i >= 0; i -= 1) {
 
   return (
     <>
-      {/* Definiciones mejoradas con estilo premium */}
-      <defs>
-        <filter id="rowShadowChart" x="-10%" y="-10%" width="120%" height="120%">
-          <feDropShadow dx="0" dy="2" stdDeviation="4" floodColor="rgba(244, 114, 182, 0.2)" />
-        </filter>
-        <pattern id="spotting-pattern-chart" patternUnits="userSpaceOnUse" width="6" height="6">
-          <rect width="6" height="6" fill="#fb7185" />
-          <circle cx="3" cy="3" r="1.5" fill="rgba(255,255,255,0.85)" />
-        </pattern>
-        
-        <filter id="pointGlow" x="-50%" y="-50%" width="200%" height="200%">
-          <feGaussianBlur stdDeviation="3" result="coloredBlur"/>
-          <feMerge>
-            <feMergeNode in="coloredBlur"/>
-            <feMergeNode in="SourceGraphic"/>
-          </feMerge>
-        </filter>
-
-
-        <radialGradient id="tempPointGradientChart" cx="30%" cy="30%">
-          <stop offset="0%" stopColor="#FDF2F8" />
-          <stop offset="50%" stopColor="#F9A8D4" />
-          <stop offset="85%" stopColor="#EC4899" />
-          <stop offset="100%" stopColor="#DB2777" />
-        </radialGradient>
-
-        <radialGradient id="tempPointIgnoredGradient" cx="30%" cy="30%">
-          <stop offset="0%" stopColor="#FFFFFF" />
-          <stop offset="80%" stopColor="#F8FAFC" />
-          <stop offset="100%" stopColor="#E2E8F0" />
-        </radialGradient>
-        <radialGradient id="ovulationPointGradient" cx="30%" cy="30%">
-          <stop offset="0%" stopColor="#dbeafe" />
-          <stop offset="50%" stopColor="#93c5fd" />
-          <stop offset="85%" stopColor="#3b82f6" />
-          <stop offset="100%" stopColor="#2563eb" />
-        </radialGradient>
-      </defs>
-
     <g pointerEvents="none">
+
 
       {/* Fondos de filas sutiles alineados con las tarjetas -- ocultos en modo compacto */}
 
 
       {/* Leyenda izquierda con tipografía premium */}
-      {isFullScreen && orientation !== 'portrait' && (
+      {renderMode !== 'tempsOnly' && isFullScreen && orientation !== 'portrait' && (
         <MotionG {...(reduceMotion || perfMode ? {} : { variants: itemVariants })}>
           {[
             { label: 'Fecha', row: 1, color: isFullScreen ? "#374151" : "#6B7280" },
             { label: 'Día', row: 2, color: isFullScreen ? "#374151" : "#6B7280" },
             { label: 'Símbolo', row: 3, color: isFullScreen ? "#374151" : "#6B7280" },
-            { label: 'Sens.', row: isFullScreen ? 5 : 4.5, color: SENSATION_COLOR },
-            { label: 'Apar.', row: isFullScreen ? 7 : 6, color: APPEARANCE_COLOR },
-            { label: 'Observ.', row: isFullScreen ? 9 : 7.5, color: OBSERVATION_COLOR },
+            { label: 'Sens.', row: isFullScreen ? 5 : 4.5, color: `var(${theme.rowColors.sensation.cssVar})` },
+            { label: 'Apar.', row: isFullScreen ? 7 : 6, color: `var(${theme.rowColors.appearance.cssVar})` },
+            { label: 'Observ.', row: isFullScreen ? 9 : 7.5, color: `var(${theme.rowColors.observation.cssVar})` },
             ...(showRelationsRow && relationsRowIndex != null
-              ? [{ label: 'RS', row: relationsRowIndex, color: HEART_COLOR }]
+              ? [{ label: 'RS', row: relationsRowIndex, color: theme.rowColors.relations.fallback }]
               : []),
           ].map(({ label, row, color }) => (
             <text
@@ -595,11 +517,11 @@ for (let i = orderedAscending.length - 1; i >= 0; i -= 1) {
         const symbolInfo = getSymbolAppearance(point.fertility_symbol);
         const symbolPalette = getSymbolColorPalette(symbolInfo.value);
         const symbolFillStyle = symbolInfo.pattern === 'spotting-pattern'
-          ? 'url(#spotting-pattern-chart)'
+          ? `url(#${ids.spottingPatternId})`
           : symbolPalette.main;
         const symbolStrokeColor = symbolPalette.border === 'none'
           ? 'none'
-          : (symbolPalette.border || SYMBOL_BORDER_FALLBACK);
+          : (symbolPalette.border || theme.symbol.borderFallback);
         const symbolStrokeWidth = symbolPalette.border === 'none'
           ? 0
           : (symbolInfo.value === 'white' ? 1.6 : 1);
@@ -623,7 +545,7 @@ for (let i = orderedAscending.length - 1; i >= 0; i -= 1) {
         const isTodayPoint = point.isoDate
           ? isSameDay(parseISO(point.isoDate), today)
           : false;
-        const highlightedTextFill = isTodayPoint ? TODAY_HIGHLIGHT_COLOR : baseTextFill;
+        const highlightedTextFill = isTodayPoint ? theme.misc.today : baseTextFill;
 
         const hasHighOrder = highSequenceOrderMap.has(index);
         const highOrder = hasHighOrder ? highSequenceOrderMap.get(index) : null;
@@ -698,7 +620,7 @@ const observationFontSize = obsRes.fontSize;
             {...(reduceMotion || perfMode ? {} : { variants: itemVariants })}
           >
             {/* Punto de temperatura con diseño premium */}
-            {hasTemp && (
+            {renderMode !== 'rowsOnly' && hasTemp && (
               <MotionG {...(reduceMotion || perfMode ? {} : { variants: pointVariants })}>
                 {/* Indicador de corrección: punto original y línea discontinua */}
                 {showCorrectionIndicator && rawY !== null && (
@@ -708,7 +630,7 @@ const observationFontSize = obsRes.fontSize;
                       y1={rawY}
                       x2={x}
                       y2={y}
-                      stroke={CORRECTION_LINE_COLOR}
+                      stroke={theme.misc.correctionLine}
                       strokeWidth={1}
                       strokeDasharray="4 4"
                     />
@@ -716,8 +638,8 @@ const observationFontSize = obsRes.fontSize;
                       cx={x}
                       cy={rawY}
                       r={3}
-                      fill={CORRECTION_POINT_FILL}
-                      stroke={CORRECTION_POINT_STROKE}
+                      fill={theme.misc.correctionPointFill}
+                      stroke={theme.misc.correctionPointStroke}
                       strokeWidth={1}
                     />
                     <circle
@@ -737,10 +659,10 @@ const observationFontSize = obsRes.fontSize;
                   r={isPeakTemperaturePoint ? 3.5 : 2.8}
                   fill={
                     isIgnoredForDisplay
-                      ? 'url(#tempPointIgnoredGradient)'
+                      ? `url(#${ids.tempPointIgnoredGradientId})`
                       : isPeakTemperaturePoint
-                        ? 'url(#ovulationPointGradient)'
-                        : 'url(#tempPointGradientChart)'
+                        ? `url(#${ids.ovulationPointGradientId})`
+                        : `url(#${ids.tempPointGradientId})`
                   }
                   stroke={
                     point.use_corrected && isCorrectedDisplayed
@@ -782,7 +704,7 @@ const observationFontSize = obsRes.fontSize;
                         textAnchor="middle"
                         fontSize={numberFontSize}
                         fontWeight="900"
-                        fill={HIGH_SEQUENCE_NUMBER_COLOR}
+                        fill={theme.misc.highSequenceNumber}
 
                         strokeWidth={numberStrokeWidth}
                         style={{
@@ -807,7 +729,7 @@ const observationFontSize = obsRes.fontSize;
                         textAnchor="middle"
                         fontSize={numberFontSize}
                         fontWeight="800"
-                        fill={BASELINE_NUMBER_COLOR}
+                        fill={theme.misc.baselineNumber}
                         stroke="#ffffff"
                         strokeWidth={numberStrokeWidth}
                         style={{
@@ -824,8 +746,9 @@ const observationFontSize = obsRes.fontSize;
                 </MotionG>
               )}
 
+
             {/* Fecha con estilo mejorado */}
-            {shouldRenderXLabel && (
+            {renderMode !== 'tempsOnly' && shouldRenderXLabel && (
               <text
                 x={x}
                 y={dateRowY}
@@ -843,7 +766,7 @@ const observationFontSize = obsRes.fontSize;
             )}
 
             {/* Día del ciclo con estilo mejorado */}
-            {shouldRenderXLabel && (
+            {renderMode !== 'tempsOnly' && shouldRenderXLabel && (
               <text
                 x={x}
                 y={cycleDayRowY}
@@ -861,7 +784,7 @@ const observationFontSize = obsRes.fontSize;
             )}
 
             {/* Símbolo mejorado con mejor diseño */}
-            {shouldRenderSymbol ? (
+            {renderMode !== 'tempsOnly' && (shouldRenderSymbol ? (
               <g>
                 {/* Sombra del símbolo */}
                 <rect
@@ -894,7 +817,7 @@ const observationFontSize = obsRes.fontSize;
                         textAnchor="middle"
                         fontSize={responsiveFontSize(1.35)}
                         fontWeight="900"
-                        fill={PEAK_EMOJI_COLOR}
+                        fill={theme.symbol.peakEmoji}
                         stroke="#fff"
                         strokeWidth={1.5}
                         paintOrder="stroke"
@@ -909,7 +832,7 @@ const observationFontSize = obsRes.fontSize;
                         textAnchor="middle"
                         fontSize={responsiveFontSize(peakStatus ? 1.1 : 1)}
                         fontWeight="800"
-                        fill={POST_PEAK_MARKER_COLOR}
+                        fill={theme.symbol.postPeak}
                         style={{ filter: textShadowStrong }}
                       >
                         {peakStatus}
@@ -918,7 +841,7 @@ const observationFontSize = obsRes.fontSize;
                   </g>
                 )}
               </g>
-            ) : (
+) : (
               <g>
                 {isPeakSeriesDay && (
                   <rect
@@ -927,7 +850,7 @@ const observationFontSize = obsRes.fontSize;
                     width={symbolRectSize * 1.4}
                     height={symbolRectSize}
                     fill="transparent"
-                    stroke={isPeakMarker ? PEAK_EMOJI_COLOR : POST_PEAK_MARKER_COLOR}
+                    stroke={isPeakMarker ? theme.symbol.peakEmoji : theme.symbol.postPeak}
                     strokeWidth={1}
                     rx={symbolRectSize * 0.2}
                   />
@@ -941,9 +864,9 @@ const observationFontSize = obsRes.fontSize;
                   )}
                   fill={
                     isPeakMarker
-                      ? PEAK_EMOJI_COLOR
+                      ? theme.symbol.peakEmoji
                       : isPostPeakMarker
-                        ? POST_PEAK_MARKER_COLOR
+                        ? theme.symbol.postPeak
                         : baseTextFill
                   }
                   fontWeight={isPeakMarker ? '900' : isPostPeakMarker ? '800' : '500'}
@@ -958,17 +881,17 @@ const observationFontSize = obsRes.fontSize;
                   {peakDisplay}
                 </text>
               </g>
-            )}
+            ))}
 
             {/* Textos con tipografía mejorada y colores premium */}
-            {!compact && (
+            {renderMode !== 'tempsOnly' && !compact && (
             <text 
               x={x} 
               y={sensY} 
               textAnchor="middle"
               fontSize={sensationFontSize} 
               fontWeight="700"
-              fill={SENSATION_COLOR}
+              fill={`var(${theme.rowColors.sensation.cssVar})`}
               style={{ 
                 fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
                 filter: textShadowStrong
@@ -980,14 +903,14 @@ const observationFontSize = obsRes.fontSize;
             </text>
             )}
 
-            {!compact && (
+            {renderMode !== 'tempsOnly' && !compact && (
             <text 
               x={x} 
               y={aparY} 
               textAnchor="middle"
               fontSize={appearanceFontSize} 
               fontWeight="700"
-              fill={APPEARANCE_COLOR}
+              fill={`var(${theme.rowColors.appearance.cssVar})`}
               style={{ 
                 fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
                 filter: textShadowStrong
@@ -999,14 +922,14 @@ const observationFontSize = obsRes.fontSize;
             </text>
             )}
             
-            {!compact && (
+            {renderMode !== 'tempsOnly' && !compact && (
             <text
               x={x}
               y={obsY}
               textAnchor="middle"
               fontSize={observationFontSize}
               fontWeight="700"
-              fill={OBSERVATION_COLOR}
+              fill={`var(${theme.rowColors.observation.cssVar})`}
               style={{
                 fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
                 filter: textShadowStrong
@@ -1018,7 +941,7 @@ const observationFontSize = obsRes.fontSize;
             </text>
             )}
 
-            {showRelationsRow && relationsRowY != null && hasRelations && (
+            {renderMode !== 'tempsOnly' && showRelationsRow && relationsRowY != null && hasRelations && (
               <g
                 transform={`translate(${x - relationsHeartSize / 2}, ${relationsRowY - relationsHeartSize / 2})`}
                 role="img"
@@ -1027,8 +950,8 @@ const observationFontSize = obsRes.fontSize;
                 <Heart
                   width={relationsHeartSize}
                   height={relationsHeartSize}
-                  color={HEART_COLOR}
-                  fill={HEART_COLOR}
+                  color={theme.rowColors.relations.fallback}
+                  fill={theme.rowColors.relations.fallback}
                 />
               </g>
             )}
@@ -1063,6 +986,9 @@ const areEqual = (prev, next) => {
   if (prev.showRelationsRow !== next.showRelationsRow) return false;
   if (prev.autoLabelStep !== next.autoLabelStep) return false;
   if (prev.isArchivedCycle !== next.isArchivedCycle) return false;
+  if (prev.renderMode !== next.renderMode) return false;
+  if (prev.ids !== next.ids) return false;
+  if (prev.theme !== next.theme) return false;
 
   const prevRange = prev.visibleRange;
   const nextRange = next.visibleRange;

--- a/src/components/chartElements/ChartSvgDefs.jsx
+++ b/src/components/chartElements/ChartSvgDefs.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+
+const renderStops = (stops = []) =>
+  stops.map((stop) => <stop key={`${stop.offset}-${stop.color}`} offset={stop.offset} stopColor={stop.color} />);
+
+const ChartSvgDefs = ({ ids, theme }) => (
+  <defs>
+    <linearGradient id={ids.bgGradientId} x1="0%" y1="0%" x2="0%" y2="100%">{renderStops(theme.bgGradient)}</linearGradient>
+    <linearGradient id={ids.dataZoneGradientId} x1="0%" y1="0%" x2="0%" y2="100%">{renderStops(theme.dataZoneGradient)}</linearGradient>
+    <linearGradient id={ids.tempLineGradientId} x1="0%" y1="0%" x2="100%" y2="0%">{renderStops(theme.tempLineGradient)}</linearGradient>
+    <linearGradient id={ids.tempLineGlowGradientId} x1="0%" y1="0%" x2="100%" y2="0%">{renderStops(theme.tempLineGlowGradient)}</linearGradient>
+
+    <radialGradient id={ids.tempPointGradientId} cx="30%" cy="30%">{renderStops(theme.tempPointRadialGradient)}</radialGradient>
+    <radialGradient id={ids.tempPointIgnoredGradientId} cx="30%" cy="30%">{renderStops(theme.tempPointIgnoredGradient)}</radialGradient>
+    <radialGradient id={ids.ovulationPointGradientId} cx="30%" cy="30%">{renderStops(theme.ovulationPointGradient)}</radialGradient>
+
+    <filter id={ids.textShadowFilterId} x="-50%" y="-50%" width="200%" height="200%">
+      <feDropShadow dx="0" dy="1" stdDeviation="1" floodColor="rgba(255, 255, 255, 0.8)" />
+    </filter>
+    <filter id={ids.softShadowFilterId}>
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2" />
+      <feOffset dx="0" dy="1" result="offsetblur" />
+      <feComponentTransfer><feFuncA type="linear" slope="0.2" /></feComponentTransfer>
+      <feMerge><feMergeNode /><feMergeNode in="SourceGraphic" /></feMerge>
+    </filter>
+    <filter id={ids.lineShadowFilterId} x="-50%" y="-50%" width="200%" height="200%">
+      <feDropShadow dx="0" dy="2" stdDeviation="3" floodColor="rgba(244, 114, 182, 0.4)" />
+    </filter>
+    <filter id={ids.lineGlowFilterId} x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="2" result="coloredBlur" />
+      <feMerge><feMergeNode in="coloredBlur" /><feMergeNode in="SourceGraphic" /></feMerge>
+    </filter>
+    <filter id={ids.pointGlowFilterId} x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="3" result="coloredBlur" />
+      <feMerge><feMergeNode in="coloredBlur" /><feMergeNode in="SourceGraphic" /></feMerge>
+    </filter>
+
+    <pattern id={ids.spottingPatternId} patternUnits="userSpaceOnUse" width="6" height="6">
+      <rect width="6" height="6" fill="#fb7185" />
+      <circle cx="3" cy="3" r="1.5" fill="rgba(255,255,255,0.85)" />
+    </pattern>
+  </defs>
+);
+
+export default ChartSvgDefs;

--- a/src/components/chartElements/chartIds.js
+++ b/src/components/chartElements/chartIds.js
@@ -1,0 +1,15 @@
+export const createChartIds = (prefix = 'fertility-chart') => ({
+  bgGradientId: `${prefix}-bg-gradient`,
+  dataZoneGradientId: `${prefix}-data-zone-gradient`,
+  tempLineGradientId: `${prefix}-temp-line-gradient`,
+  tempLineGlowGradientId: `${prefix}-temp-line-glow-gradient`,
+  tempPointGradientId: `${prefix}-temp-point-gradient`,
+  tempPointIgnoredGradientId: `${prefix}-temp-point-ignored-gradient`,
+  ovulationPointGradientId: `${prefix}-ovulation-point-gradient`,
+  textShadowFilterId: `${prefix}-text-shadow-filter`,
+  softShadowFilterId: `${prefix}-soft-shadow-filter`,
+  lineShadowFilterId: `${prefix}-line-shadow-filter`,
+  lineGlowFilterId: `${prefix}-line-glow-filter`,
+  pointGlowFilterId: `${prefix}-point-glow-filter`,
+  spottingPatternId: `${prefix}-spotting-pattern`,
+});

--- a/src/components/chartElements/chartLayout.js
+++ b/src/components/chartElements/chartLayout.js
@@ -1,0 +1,79 @@
+import { FONT_FAMILY } from '@/components/chartElements/chartTheme';
+
+export const getRowMetrics = ({
+  graphBottomY,
+  isFullScreen,
+  rowsZoneHeight,
+  textRowHeight,
+  showRelationsRow,
+}) => {
+  const rowsTopY = graphBottomY;
+  const obsRowIndex = isFullScreen ? 9 : 7.5;
+  const halfBlock = isFullScreen ? 1 : 0.75;
+  const baseRowCount = obsRowIndex + halfBlock;
+  const autoRowH = Math.max(1, Math.floor(rowsZoneHeight / baseRowCount));
+  const rowH = Math.max(textRowHeight, autoRowH);
+
+  const dateRowY = rowsTopY + rowH * 1;
+  const cycleDayRowY = rowsTopY + rowH * 2;
+  const symbolRowYBase = rowsTopY + rowH * 3;
+  const mucusSensationRowY = rowsTopY + rowH * (isFullScreen ? 5 : 4.5);
+  const mucusAppearanceRowY = rowsTopY + rowH * (isFullScreen ? 7 : 6);
+  const observationsRowY = rowsTopY + rowH * (isFullScreen ? 9 : 7.5);
+  const relationsRowY = showRelationsRow
+    ? observationsRowY + rowH * (isFullScreen ? 2 : 1.5)
+    : null;
+
+  return {
+    rowsTopY,
+    obsRowIndex,
+    halfBlock,
+    baseRowCount,
+    autoRowH,
+    rowH,
+    dateRowY,
+    cycleDayRowY,
+    symbolRowYBase,
+    mucusSensationRowY,
+    mucusAppearanceRowY,
+    observationsRowY,
+    relationsRowY,
+  };
+};
+
+const buildFontString = (fontSize, fontWeight, fontFamily = FONT_FAMILY) =>
+  `${fontWeight} ${fontSize}px ${fontFamily}`;
+
+const createFallbackMeasure = () => (text, font) => {
+  const match = /(\d+(?:\.\d+)?)px/.exec(font || '');
+  const fontSize = match ? Number(match[1]) : 12;
+  return String(text || '').length * fontSize * 0.6;
+};
+
+export const getLabelStep = ({
+  totalPoints,
+  getX,
+  responsiveFontSize,
+  data,
+  measureTextWidth,
+  fontFamily = FONT_FAMILY,
+}) => {
+  if (totalPoints < 2) return 1;
+  const dayWidth = Math.abs(getX(1) - getX(0));
+  if (!Number.isFinite(dayWidth) || dayWidth <= 0) return 1;
+  const samplePoint = data?.find((entry) => entry?.date || entry?.cycleDay != null) ?? {};
+  const compactDate = (dateStr) => {
+    if (!dateStr) return '00/00';
+    const [d, m] = String(dateStr).split('/');
+    return `${parseInt(d, 10)}/${parseInt(m, 10)}`;
+  };
+
+  const measure = measureTextWidth || createFallbackMeasure();
+  const sampleDate = compactDate(samplePoint?.date);
+  const sampleDay = String(samplePoint?.cycleDay ?? totalPoints ?? '');
+  const dateWidth = measure(sampleDate, buildFontString(responsiveFontSize(1.05), 900, fontFamily));
+  const dayWidthText = measure(sampleDay, buildFontString(responsiveFontSize(1), 900, fontFamily));
+  const minLabelWidth = Math.max(dateWidth, dayWidthText) + responsiveFontSize(0.8);
+
+  return Math.max(1, Math.ceil(minLabelWidth / dayWidth));
+};

--- a/src/components/chartElements/chartTheme.js
+++ b/src/components/chartElements/chartTheme.js
@@ -1,0 +1,110 @@
+export const FONT_FAMILY = '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif';
+
+const ROOT_CSS_VARS = {
+  sensation: '--color-sensacion-fuerte',
+  appearance: '--color-apariencia-fuerte',
+  observation: '--color-observaciones-fuerte',
+};
+
+export const THEME = {
+  bgGradient: [
+    { offset: '0%', color: '#fffbfc' },
+    { offset: '50%', color: '#fff5f7' },
+    { offset: '100%', color: '#fff1f3' },
+  ],
+  dataZoneGradient: [
+    { offset: '0%', color: '#fff7fb' },
+    { offset: '50%', color: '#ffe4f0' },
+    { offset: '100%', color: '#fff7fb' },
+  ],
+  tempLineGradient: [
+    { offset: '0%', color: '#f472b6' },
+    { offset: '30%', color: '#ec4899' },
+    { offset: '70%', color: '#db2777' },
+    { offset: '100%', color: '#be185d' },
+  ],
+  tempLineGlowGradient: [
+    { offset: '0%', color: '#f9a8d4' },
+    { offset: '100%', color: '#ec4899' },
+  ],
+  tempPointRadialGradient: [
+    { offset: '0%', color: '#FDF2F8' },
+    { offset: '50%', color: '#F9A8D4' },
+    { offset: '85%', color: '#EC4899' },
+    { offset: '100%', color: '#DB2777' },
+  ],
+  tempPointIgnoredGradient: [
+    { offset: '0%', color: '#FFFFFF' },
+    { offset: '80%', color: '#F8FAFC' },
+    { offset: '100%', color: '#E2E8F0' },
+  ],
+  ovulationPointGradient: [
+    { offset: '0%', color: '#dbeafe' },
+    { offset: '50%', color: '#93c5fd' },
+    { offset: '85%', color: '#3b82f6' },
+    { offset: '100%', color: '#2563eb' },
+  ],
+  grid: {
+    major: '#f9a8d4',
+    minor: '#fce7f3',
+    vertical: '#fce7f3',
+  },
+  text: {
+    axisMajor: '#be185d',
+    axisMinor: '#db2777',
+    dateDay: '#60666f',
+    neutral: '#374151',
+  },
+  card: {
+    fill: '#ffffff',
+    border: 'rgba(244, 114, 182, 0.20)',
+    shadowRGBA: 'rgba(244, 114, 182, 0.10)',
+  },
+  baseline: {
+    strokeDefault: '#F59E0B',
+    dashDefault: '6 4',
+    opacityDefault: 1,
+  },
+  highlight: {
+    strokeTop: 'rgba(235, 171, 204,0.15)',
+    strokeBottom: 'rgba(235, 171, 204,0.32)',
+    alphaTop: 0.15,
+    alphaBottom: 0.32,
+  },
+  rowColors: {
+    sensation: { cssVar: ROOT_CSS_VARS.sensation, fallback: '#0ea5e9' },
+    appearance: { cssVar: ROOT_CSS_VARS.appearance, fallback: '#10b981' },
+    observation: { cssVar: ROOT_CSS_VARS.observation, fallback: '#8b5cf6' },
+    relations: { fallback: '#f44336' },
+  },
+  symbol: {
+    peakEmoji: '#ec4899',
+    postPeak: '#7f1d1d',
+    borderFallback: 'rgba(244, 114, 182, 0.35)',
+  },
+  misc: {
+    correctionLine: 'rgba(148, 163, 184, 0.35)',
+    correctionPointFill: 'rgba(226, 232, 240, 0.6)',
+    correctionPointStroke: 'rgba(148, 163, 184, 0.5)',
+    today: '#be185d',
+    baselineNumber: '#2563eb',
+    highSequenceNumber: '#be185d',
+    textShadowWhite: 'rgba(255, 255, 255, 0.9)',
+  },
+};
+
+export const resolveCssVar = (varName, fallback) => {
+  if (typeof window === 'undefined' || !window.getComputedStyle) return fallback;
+  const value = window.getComputedStyle(document.documentElement).getPropertyValue(varName);
+  return value?.trim() || fallback;
+};
+
+export const getCanvasTheme = () => ({
+  ...THEME,
+  rowColors: {
+    sensation: resolveCssVar(THEME.rowColors.sensation.cssVar, THEME.rowColors.sensation.fallback),
+    appearance: resolveCssVar(THEME.rowColors.appearance.cssVar, THEME.rowColors.appearance.fallback),
+    observation: resolveCssVar(THEME.rowColors.observation.cssVar, THEME.rowColors.observation.fallback),
+    relations: THEME.rowColors.relations.fallback,
+  },
+});

--- a/src/components/chartElements/chartTicks.js
+++ b/src/components/chartElements/chartTicks.js
@@ -1,0 +1,12 @@
+export const getTempTicks = ({ tempMin, tempMax, tempRange }) => {
+  const ticks = [];
+  if (tempRange > 0) {
+    const increment = tempRange <= 2.5 ? 0.1 : 0.5;
+    for (let t = tempMin; t <= tempMax + 1e-9; t += increment) {
+      ticks.push(Number(t.toFixed(1)));
+    }
+    return ticks;
+  }
+  for (let t = 35.8; t <= 37.2 + 1e-9; t += 0.1) ticks.push(Number(t.toFixed(1)));
+  return ticks;
+};

--- a/src/components/chartElements/chartVisibleRange.js
+++ b/src/components/chartElements/chartVisibleRange.js
@@ -1,0 +1,27 @@
+export const computeVisibleRange = ({ xs, scrollLeft, viewportW, overscanPx = viewportW * 1.5 }) => {
+  if (!Array.isArray(xs) || xs.length === 0) {
+    return { startIndex: 0, endIndex: -1 };
+  }
+
+  const minX = scrollLeft - overscanPx;
+  const maxX = scrollLeft + viewportW + overscanPx;
+
+  let lo = 0;
+  let hi = xs.length - 1;
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    if (xs[mid] < minX) lo = mid + 1;
+    else hi = mid;
+  }
+  const startIndex = Math.max(0, lo - 1);
+
+  lo = 0;
+  hi = xs.length - 1;
+  while (lo < hi) {
+    const mid = ((lo + hi) >> 1) + 1;
+    if (xs[mid] > maxX) hi = mid - 1;
+    else lo = mid;
+  }
+  const endIndex = Math.min(xs.length - 1, lo + 1);
+  return { startIndex, endIndex };
+};


### PR DESCRIPTION
### Motivation
- Centralize repeated chart primitives (colors/gradients/filters/IDs/layout/ticks/visibleRange) to remove duplication and ease maintenance.  
- Improve mobile performance by moving heavy painting into Canvas while keeping text/rows as an SVG overlay for perfect visual parity in SVG/export mode.  
- Preserve existing SVG visuals when `exportMode=true` or `USE_CANVAS=false` (no visual regressions) and enable a hybrid rendering for `USE_CANVAS=true && !exportMode`.

### Description
- Added shared primitives: `src/components/chartElements/chartTheme.js`, `chartIds.js`, `chartTicks.js`, `chartLayout.js`, and `chartVisibleRange.js` to centralize theme, CSS var resolution for Canvas, unique defs ids, tick generation, row metrics and label-step, and binary visible-range computation.  
- Introduced `ChartSvgDefs.jsx` to render a single instance of `<defs>` (gradients/filters/patterns) and removed duplicated defs from `ChartAxes`, `ChartLine`, and `ChartPoints`.  
- Updated `FertilityChart.jsx` to create per-instance ids (`createChartIds(uniqueId)`), use `computeVisibleRange` (binary search over `xs`), and implement the hybrid mode: Canvas draws heavy layers while a sticky SVG overlay (imperatively synced via refs + `requestAnimationFrame`) renders rows/texts (`ChartPoints renderMode="rowsOnly"`).  
- Refactored Canvas and SVG components to consume the shared modules: `FertilityChartCanvas.jsx` now uses `getCanvasTheme()` and `getTempTicks()` and receives `visibleRange` from the parent; `ChartAxes.jsx`, `ChartLine.jsx`, `ChartPoints.jsx`, and `ChartLeftLegend.jsx` now accept `ids` + `theme` and use `getTempTicks` / `getRowMetrics` / `getLabelStep` to avoid duplicated logic; `ChartPoints` gained `renderMode` (`full` | `rowsOnly` | `tempsOnly`).

### Testing
- Built the production bundle with `npm run build`, which completed successfully (build artifacts produced).  
- Attempted to run the dev server and capture a screenshot via Playwright (`npm run dev` + Playwright); the Playwright navigation failed with `ERR_EMPTY_RESPONSE` when accessing `http://localhost:4173`, so no headless visual snapshot was captured (server start/run environment in CI/container may require further verification).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6a9fcc9008333917b365a47293418)