### PR TITLE
Add master /settings/preferences page and centralize preference logic

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,6 +14,7 @@ const DashboardPage = lazy(() => import('@/pages/DashboardPage'));
 const ArchivedCyclesPage = lazy(() => import('@/pages/ArchivedCyclesPage'));
 const CycleDetailPage = lazy(() => import('@/pages/CycleDetailPage'));
 const SettingsPage = lazy(() => import('@/pages/SettingsPage'));
+const PreferencesPage = lazy(() => import('@/pages/PreferencesPage'));
 const ChartPage = lazy(() => import('@/pages/ChartPage'));
 const RecordsPage = lazy(() => import('@/pages/RecordsPage'));
 import MainLayout from '@/components/layout/MainLayout';
@@ -132,6 +133,16 @@ function AppContent() {
                   <ProtectedRoute>
                     <MainLayout>
                       <SettingsPage />
+                    </MainLayout>
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path="/settings/preferences"
+                element={
+                  <ProtectedRoute>
+                    <MainLayout>
+                      <PreferencesPage />
                     </MainLayout>
                   </ProtectedRoute>
                 }

--- a/src/components/dataEntryForm/DataEntryFormFields.jsx
+++ b/src/components/dataEntryForm/DataEntryFormFields.jsx
@@ -41,6 +41,7 @@ import {
   SECTION_METADATA,
 } from '@/components/dataEntryForm/sectionLogic';
 import { useAuth } from '@/contexts/AuthContext';
+import { normalizePreferenceValue, validatePreferenceField } from '@/lib/preferences';
 const VIEW_ALL_STORAGE_KEY = 'dataEntryForm:viewAll:global';
 const DEFAULT_SECTION_STORAGE_KEY = '__default__';
 const RADIUS = { field: 'rounded-3xl', dropdown: 'rounded-3xl' };
@@ -102,9 +103,10 @@ const DataEntryFormFields = ({
   const [isSavingPreferredTime, setIsSavingPreferredTime] = useState(false);
   const initializedSectionsRef = useRef(false);
   const preferredTemperatureTime =
-    typeof preferences?.preferredTemperatureTime === 'string'
-      ? preferences.preferredTemperatureTime
-      : '';
+    normalizePreferenceValue(
+      'preferredTemperatureTime',
+      preferences?.preferredTemperatureTime
+    );
 
   const sectionOrder = useMemo(
     () => [
@@ -253,7 +255,11 @@ const [activeSection, setActiveSection] = useState(() => {
 
   const handleSavePreferredTime = useCallback(
     async (measurementIndex) => {
-      if (!preferredTimeDraft || !/^\d{2}:\d{2}$/.test(preferredTimeDraft)) {
+      const preferredTimeError = validatePreferenceField(
+        'preferredTemperatureTime',
+        preferredTimeDraft
+      );
+      if (preferredTimeError) {
         return;
       }
 

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -15,6 +15,11 @@ import {
 import { deleteField, doc, getDoc, setDoc, getDocFromCache } from 'firebase/firestore';
 import { useToast } from '@/components/ui/use-toast';
 import {
+  PREFERENCE_DEFAULTS,
+  normalizeStoredPreferences,
+  normalizePreferencePatch,
+} from '@/lib/preferences';
+import {
   trackEvent,
   trackLogin,
   trackSignUp,
@@ -96,54 +101,6 @@ const ensurePersistentStorage = async (phase) => {
     });
   }
 };
-const COMBINE_MODE_OPTIONS = new Set(['estandar']);
-
-const normalizeCombineMode = (value) => {
-  if (value === 'conservador') return 'estandar';
-  return COMBINE_MODE_OPTIONS.has(value) ? value : null;
-};
-
-const createDefaultFertilityStartConfig = () => ({
-  calculators: { cpm: true, t8: true },
-  combineMode: 'estandar',
-});
-
-const mergeFertilityStartConfig = ({ current, incoming, legacyCombineMode }) => {
-  const base = createDefaultFertilityStartConfig();
-  const merged = {
-    calculators: { ...base.calculators },
-    combineMode: base.combineMode,
-  };
-  let combineModeSet = false;
-
-  const applyConfig = (source) => {
-    if (!source || typeof source !== 'object') return;
-    Object.keys(merged.calculators).forEach((key) => {
-      if (typeof source?.calculators?.[key] === 'boolean') {
-        merged.calculators[key] = source.calculators[key];
-      }
-    });
-
-    const normalizedMode = normalizeCombineMode(source.combineMode);
-    if (normalizedMode) {
-      merged.combineMode = normalizedMode;
-      combineModeSet = true;
-    }
-  };
-
-  applyConfig(current);
-  applyConfig(incoming);
-
-  if (!combineModeSet) {
-    const legacyMode = normalizeCombineMode(legacyCombineMode);
-    if (legacyMode) {
-      merged.combineMode = legacyMode;
-    }
-  }
-
-  return merged;
-};
-
 export const AuthProvider = ({ children }) => {
   const [user, setUser] = useState(null);
   const [loadingAuth, setLoadingAuth] = useState(true);
@@ -188,38 +145,12 @@ export const AuthProvider = ({ children }) => {
           }
 
           const prefRef = doc(db, `users/${firebaseUser.uid}/preferences`, 'display');
-          const defaultPreferences = {
-            theme: 'light',
-            units: 'metric',
-            preferredTemperatureTime: '',
-            manualCpm: null,
-            manualT8: null,
-            manualCpmBase: null,
-            manualT8Base: null,
-            cpmMode: 'auto',
-            t8Mode: 'auto',
-            showRelationsRow: true,
-            fertilityStartConfig: createDefaultFertilityStartConfig(),
-          };
+          const defaultPreferences = normalizeStoredPreferences(PREFERENCE_DEFAULTS);
           try {
             try {
               const cacheSnap = await getDocFromCache(prefRef);
               if (cacheSnap.exists()) {
-                const {
-                  combineMode: legacyCombineMode,
-                  fertilityStartConfig: storedFertilityStartConfig,
-                  ...restPreferences
-                } = cacheSnap.data();
-                const mergedFertilityStartConfig = mergeFertilityStartConfig({
-                  current: defaultPreferences.fertilityStartConfig,
-                  incoming: storedFertilityStartConfig,
-                  legacyCombineMode,
-                });
-                setPreferences({
-                  ...defaultPreferences,
-                  ...restPreferences,
-                  fertilityStartConfig: mergedFertilityStartConfig,
-                });
+                setPreferences(normalizeStoredPreferences(cacheSnap.data()));
               }
             } catch (cacheError) {
               // Ignore cache errors; we'll try the network next.
@@ -227,21 +158,7 @@ export const AuthProvider = ({ children }) => {
 
             const prefSnap = await getDoc(prefRef);
             if (prefSnap.exists()) {
-              const {
-                combineMode: legacyCombineMode,
-                fertilityStartConfig: storedFertilityStartConfig,
-                ...restPreferences
-              } = prefSnap.data();
-              const mergedFertilityStartConfig = mergeFertilityStartConfig({
-                current: defaultPreferences.fertilityStartConfig,
-                incoming: storedFertilityStartConfig,
-                legacyCombineMode,
-              });
-              setPreferences({
-                ...defaultPreferences,
-                ...restPreferences,
-                fertilityStartConfig: mergedFertilityStartConfig,
-              });
+              setPreferences(normalizeStoredPreferences(prefSnap.data()));
             } else {
               setPreferences(defaultPreferences);
             }
@@ -362,49 +279,22 @@ export const AuthProvider = ({ children }) => {
   const savePreferences = async (prefs = {}) => {
     if (!auth.currentUser) return;
     const prefRef = doc(db, `users/${auth.currentUser.uid}/preferences`, 'display');
-    const {
-      combineMode: legacyCombineMode,
-      fertilityStartConfig: incomingFertilityStartConfig,
-      ...restPrefs
-    } = prefs ?? {};
-    const hasFertilityUpdate =
-      (incomingFertilityStartConfig && typeof incomingFertilityStartConfig === 'object')
-      || legacyCombineMode !== undefined;
-    const nextFertilityStartConfig = hasFertilityUpdate
-      ? mergeFertilityStartConfig({
-          current: preferences?.fertilityStartConfig,
-          incoming: incomingFertilityStartConfig,
-          legacyCombineMode,
-        })
-      : preferences?.fertilityStartConfig;
+    const currentPreferences = normalizeStoredPreferences(preferences ?? PREFERENCE_DEFAULTS);
+    const { normalizedPatch, hasFertilityUpdate } = normalizePreferencePatch(
+      prefs,
+      currentPreferences
+    );
 
-    const payload = { ...restPrefs };
-    if (hasFertilityUpdate && nextFertilityStartConfig) {
-      payload.fertilityStartConfig = nextFertilityStartConfig;
+    const payload = { ...normalizedPatch };
+    if (hasFertilityUpdate && normalizedPatch.fertilityStartConfig) {
       payload.combineMode = deleteField();
     }
 
     try {
       await setDoc(prefRef, payload, { merge: true });
       setPreferences((previous) => {
-        const current = previous ?? {
-          theme: 'light',
-          units: 'metric',
-          preferredTemperatureTime: '',
-          manualCpm: null,
-          manualT8: null,
-          manualCpmBase: null,
-          manualT8Base: null,
-          cpmMode: 'auto',
-          t8Mode: 'auto',
-          showRelationsRow: true,
-          fertilityStartConfig: createDefaultFertilityStartConfig(),
-        };
-        const next = { ...current, ...restPrefs };
-        if (hasFertilityUpdate && nextFertilityStartConfig) {
-          next.fertilityStartConfig = nextFertilityStartConfig;
-        }
-        return next;
+        const current = normalizeStoredPreferences(previous ?? PREFERENCE_DEFAULTS);
+        return normalizeStoredPreferences({ ...current, ...normalizedPatch });
       });
     } catch (error) {
       console.error('Failed to save preferences', error);

--- a/src/lib/preferences/index.js
+++ b/src/lib/preferences/index.js
@@ -1,0 +1,225 @@
+const COMBINE_MODE_OPTIONS = new Set(['estandar']);
+
+export const createDefaultFertilityStartConfig = () => ({
+  calculators: { cpm: true, t8: true },
+  combineMode: 'estandar',
+});
+
+export const PREFERENCE_DEFAULTS = {
+  theme: 'light',
+  units: 'metric',
+  preferredTemperatureTime: '',
+  manualCpm: null,
+  manualT8: null,
+  manualCpmBase: null,
+  manualT8Base: null,
+  cpmMode: 'auto',
+  t8Mode: 'auto',
+  showRelationsRow: true,
+  fertilityStartConfig: createDefaultFertilityStartConfig(),
+};
+
+export const PREFERENCES_UI_FIELDS = [
+  'preferredTemperatureTime',
+  'cpmMode',
+  'manualCpm',
+  'manualCpmBase',
+  't8Mode',
+  'manualT8',
+  'manualT8Base',
+  'showRelationsRow',
+  'fertilityStartConfig',
+];
+
+const CPM_MODE_OPTIONS = new Set(['auto', 'manual', 'none']);
+const T8_MODE_OPTIONS = new Set(['auto', 'manual', 'none']);
+
+export const normalizeCombineMode = (value) => {
+  if (value === 'conservador') return 'estandar';
+  return COMBINE_MODE_OPTIONS.has(value) ? value : null;
+};
+
+export const mergeFertilityStartConfig = ({ current, incoming, legacyCombineMode } = {}) => {
+  const base = createDefaultFertilityStartConfig();
+  const merged = {
+    calculators: { ...base.calculators },
+    combineMode: base.combineMode,
+  };
+  let combineModeSet = false;
+
+  const applyConfig = (source) => {
+    if (!source || typeof source !== 'object') return;
+    Object.keys(merged.calculators).forEach((key) => {
+      if (typeof source?.calculators?.[key] === 'boolean') {
+        merged.calculators[key] = source.calculators[key];
+      }
+    });
+
+    const normalizedMode = normalizeCombineMode(source.combineMode);
+    if (normalizedMode) {
+      merged.combineMode = normalizedMode;
+      combineModeSet = true;
+    }
+  };
+
+  applyConfig(current);
+  applyConfig(incoming);
+
+  if (!combineModeSet) {
+    const legacyMode = normalizeCombineMode(legacyCombineMode);
+    if (legacyMode) {
+      merged.combineMode = legacyMode;
+    }
+  }
+
+  return merged;
+};
+
+const normalizeNumberOrNull = (value) => {
+  if (value === null) return null;
+  if (value === undefined) return undefined;
+  if (value === '') return null;
+  const numberValue = Number(value);
+  return Number.isFinite(numberValue) ? numberValue : undefined;
+};
+
+export const normalizePreferenceValue = (key, value, currentPreferences = PREFERENCE_DEFAULTS) => {
+  switch (key) {
+    case 'preferredTemperatureTime':
+      return typeof value === 'string' ? value : '';
+    case 'cpmMode':
+      return CPM_MODE_OPTIONS.has(value) ? value : currentPreferences.cpmMode;
+    case 't8Mode':
+      return T8_MODE_OPTIONS.has(value) ? value : currentPreferences.t8Mode;
+    case 'showRelationsRow':
+      return typeof value === 'boolean' ? value : Boolean(currentPreferences.showRelationsRow);
+    case 'manualCpm':
+    case 'manualT8':
+    case 'manualCpmBase':
+    case 'manualT8Base': {
+      const normalized = normalizeNumberOrNull(value);
+      return normalized === undefined ? currentPreferences[key] : normalized;
+    }
+    default:
+      return value;
+  }
+};
+
+export const normalizeStoredPreferences = (rawPreferences = {}) => {
+  const defaults = {
+    ...PREFERENCE_DEFAULTS,
+    fertilityStartConfig: createDefaultFertilityStartConfig(),
+  };
+  const {
+    combineMode: legacyCombineMode,
+    fertilityStartConfig: storedFertilityStartConfig,
+    ...rest
+  } = rawPreferences ?? {};
+
+  const normalized = {
+    ...defaults,
+    ...rest,
+  };
+
+  PREFERENCES_UI_FIELDS.forEach((fieldKey) => {
+    if (fieldKey === 'fertilityStartConfig') return;
+    normalized[fieldKey] = normalizePreferenceValue(fieldKey, normalized[fieldKey], defaults);
+  });
+
+  normalized.fertilityStartConfig = mergeFertilityStartConfig({
+    current: defaults.fertilityStartConfig,
+    incoming: storedFertilityStartConfig,
+    legacyCombineMode,
+  });
+
+  return normalized;
+};
+
+export const normalizePreferencePatch = (patch = {}, currentPreferences = PREFERENCE_DEFAULTS) => {
+  const { combineMode: legacyCombineMode, fertilityStartConfig, ...restPatch } = patch ?? {};
+  const normalizedPatch = {};
+
+  Object.keys(restPatch).forEach((key) => {
+    normalizedPatch[key] = normalizePreferenceValue(key, restPatch[key], currentPreferences);
+  });
+
+  const hasFertilityUpdate =
+    (fertilityStartConfig && typeof fertilityStartConfig === 'object') || legacyCombineMode !== undefined;
+
+  if (hasFertilityUpdate) {
+    normalizedPatch.fertilityStartConfig = mergeFertilityStartConfig({
+      current: currentPreferences?.fertilityStartConfig,
+      incoming: fertilityStartConfig,
+      legacyCombineMode,
+    });
+  }
+
+  return { normalizedPatch, hasFertilityUpdate };
+};
+
+export const validatePreferenceField = (key, value, fullPreferences = {}) => {
+  switch (key) {
+    case 'preferredTemperatureTime':
+      if (!value) return null;
+      return /^\d{2}:\d{2}$/.test(value) ? null : 'Formato inválido. Usa HH:mm.';
+    case 'manualCpm':
+    case 'manualCpmBase':
+    case 'manualT8':
+    case 'manualT8Base':
+      if (value === null || value === undefined || value === '') return null;
+      return Number.isFinite(Number(value)) ? null : 'Debe ser un número válido.';
+    case 'cpmMode':
+      return CPM_MODE_OPTIONS.has(value) ? null : 'Modo CPM inválido.';
+    case 't8Mode':
+      return T8_MODE_OPTIONS.has(value) ? null : 'Modo T-8 inválido.';
+    case 'showRelationsRow':
+      return typeof value === 'boolean' ? null : 'Valor inválido.';
+    case 'fertilityStartConfig': {
+      const merged = mergeFertilityStartConfig({ incoming: value });
+      const active = Object.values(merged.calculators || {}).some(Boolean);
+      if (!active) {
+        return 'Debes mantener al menos un cálculo activo (CPM o T-8).';
+      }
+      return null;
+    }
+    default:
+      return null;
+  }
+};
+
+export const validatePreferences = (prefs = {}) => {
+  const errors = {};
+  PREFERENCES_UI_FIELDS.forEach((key) => {
+    const error = validatePreferenceField(key, prefs[key], prefs);
+    if (error) errors[key] = error;
+  });
+
+  if (prefs.cpmMode !== 'manual') {
+    errors.manualCpm = null;
+    errors.manualCpmBase = null;
+  }
+
+  if (prefs.t8Mode !== 'manual') {
+    errors.manualT8 = null;
+    errors.manualT8Base = null;
+  }
+
+  return Object.fromEntries(Object.entries(errors).filter(([, value]) => value));
+};
+
+const isEqualValue = (a, b) => {
+  if (typeof a === 'object' && a && typeof b === 'object' && b) {
+    return JSON.stringify(a) === JSON.stringify(b);
+  }
+  return a === b;
+};
+
+export const buildPreferencesDiff = (base = {}, draft = {}, keys = PREFERENCES_UI_FIELDS) => {
+  const diff = {};
+  keys.forEach((key) => {
+    if (!isEqualValue(base[key], draft[key])) {
+      diff[key] = draft[key];
+    }
+  });
+  return diff;
+};

--- a/src/pages/ChartPage.jsx
+++ b/src/pages/ChartPage.jsx
@@ -27,8 +27,11 @@ import Overlay from '@/components/ui/Overlay';
 import { useAuth } from '@/contexts/AuthContext';
 import { computeOvulationMetrics } from '@/hooks/useFertilityChart';
 import ChartControls from '@/components/ChartControls';
-
-const CHART_SETTINGS_STORAGE_KEY = 'fertility-chart-settings';
+import {
+  PREFERENCE_DEFAULTS,
+  mergeFertilityStartConfig,
+  normalizeStoredPreferences,
+} from '@/lib/preferences';
 
 const normalizeCalculatorSource = (source) => {
   if (!source) return '';
@@ -46,48 +49,12 @@ const formatCalculatorSourceLabel = (source) => {
   return source ?? '';
 };
 
-const normalizeCombineMode = (value) => {
-  if (value === 'conservador') return 'estandar';
-  return value === 'estandar' ? value : null;
-};
-
-const createDefaultFertilityStartConfig = () => ({
-  calculators: { cpm: true, t8: true },
-  combineMode: 'estandar',
-});
-
-const DEFAULT_CHART_SETTINGS = {
-  showRelationsRow: true,
-  fertilityStartConfig: createDefaultFertilityStartConfig(),
-};
+const DEFAULT_CHART_SETTINGS = normalizeStoredPreferences(PREFERENCE_DEFAULTS);
 
 const FERTILITY_CALCULATOR_OPTIONS = [
   { key: 'cpm', label: 'CPM' },
   { key: 't8', label: 'T-8' },
 ];
-
-const mergeFertilityStartConfig = (incoming) => {
-  const base = createDefaultFertilityStartConfig();
-  const merged = {
-    calculators: { ...base.calculators },
-    combineMode: base.combineMode,
-  };
-
-  if (incoming && typeof incoming === 'object') {
-    Object.keys(merged.calculators).forEach((key) => {
-      if (typeof incoming?.calculators?.[key] === 'boolean') {
-        merged.calculators[key] = incoming.calculators[key];
-      }
-    });
-
-    const normalizedMode = normalizeCombineMode(incoming.combineMode);
-    if (normalizedMode) {
-      merged.combineMode = normalizedMode;
-    }
-  }
-
-  return merged;
-};
 
 const ChartPage = () => {
   const { cycleId } = useParams();
@@ -316,84 +283,35 @@ useEffect(() => {
   return () => window.clearTimeout(t);
 }, [settingsOpen, drawerMounted]);
   const [phaseOverlay, setPhaseOverlay] = useState(null);
-  const hasStoredRelationsRowPreferenceRef = useRef(false);
   const [chartSettings, setChartSettings] = useState(() => {
-    const defaults = {
-      showRelationsRow: DEFAULT_CHART_SETTINGS.showRelationsRow,
-      fertilityStartConfig: mergeFertilityStartConfig(DEFAULT_CHART_SETTINGS.fertilityStartConfig),
+    const defaults = normalizeStoredPreferences(PREFERENCE_DEFAULTS);
+    return {
+      showRelationsRow: defaults.showRelationsRow,
+      fertilityStartConfig: mergeFertilityStartConfig({
+        current: defaults.fertilityStartConfig,
+      }),
     };
-
-    if (typeof window === 'undefined') {
-      return defaults;
-    }
-    try {
-      const stored = window.localStorage.getItem(CHART_SETTINGS_STORAGE_KEY);
-      if (stored) {
-        const parsed = JSON.parse(stored);
-        if (parsed && Object.prototype.hasOwnProperty.call(parsed, 'showRelationsRow')) {
-          hasStoredRelationsRowPreferenceRef.current = true;
-        }
-        const merged = {
-          ...defaults,
-          ...parsed,
-        };
-        if (typeof parsed?.showRelationsRow === 'boolean') {
-          merged.showRelationsRow = parsed.showRelationsRow;
-        } else if (parsed?.showRelationsRow != null) {
-          merged.showRelationsRow = Boolean(parsed.showRelationsRow);
-        }
-        merged.fertilityStartConfig = mergeFertilityStartConfig(parsed?.fertilityStartConfig);
-        return merged;
-      }
-    } catch (error) {
-      console.warn('No se pudieron cargar los ajustes del gráfico.', error);
-    }
-    
-    return defaults;
   });
   
-  useEffect(() => {
-  if (!preferences) return;
-
+useEffect(() => {
+  const normalizedPreferences = normalizeStoredPreferences(preferences ?? PREFERENCE_DEFAULTS);
+  const preferenceConfig = mergeFertilityStartConfig({
+    current: normalizedPreferences.fertilityStartConfig,
+  });
   setChartSettings((prev) => {
-    const currentConfig = mergeFertilityStartConfig(prev.fertilityStartConfig);
-    const preferenceConfig = mergeFertilityStartConfig(preferences.fertilityStartConfig);
-    let changed = false;
-
-    const shouldSyncRelationsFromPreferences =
-      !hasStoredRelationsRowPreferenceRef.current &&
-      typeof preferences.showRelationsRow === 'boolean' &&
-      prev.showRelationsRow !== preferences.showRelationsRow;
-
-    if (shouldSyncRelationsFromPreferences) {
-      changed = true;
-    }
-
-    if (currentConfig.combineMode !== preferenceConfig.combineMode) changed = true;
-
-    if (
-      Object.keys(currentConfig.calculators ?? {}).some(
-        (key) => currentConfig.calculators?.[key] !== preferenceConfig.calculators?.[key]
-      )
-    ) {
-      changed = true;
-    }
-
-    if (!changed) return prev;
-
+    const sameRelations = prev.showRelationsRow === normalizedPreferences.showRelationsRow;
+    const sameConfig = JSON.stringify(prev.fertilityStartConfig) === JSON.stringify(preferenceConfig);
+    if (sameRelations && sameConfig) return prev;
     return {
       ...prev,
-      showRelationsRow:
-        shouldSyncRelationsFromPreferences
-          ? preferences.showRelationsRow
-          : prev.showRelationsRow,
+      showRelationsRow: normalizedPreferences.showRelationsRow,
       fertilityStartConfig: preferenceConfig,
     };
   });
 }, [preferences]);
 
   const fertilityConfig = useMemo(
-    () => mergeFertilityStartConfig(chartSettings.fertilityStartConfig),
+    () => mergeFertilityStartConfig({ incoming: chartSettings.fertilityStartConfig }),
     [chartSettings.fertilityStartConfig]
   );
   const cyclePostpartumMode = Boolean(targetCycle?.postpartumMode);
@@ -410,21 +328,6 @@ useEffect(() => {
     }),
     [fertilityConfig, cpmSelection, t8Selection, cyclePostpartumMode]
   );
-
-  useEffect(() => {
-    if (typeof window === 'undefined') {
-      return;
-    }
-    try {
-      const payload = { ...chartSettings, fertilityStartConfig: fertilityConfig };
-      window.localStorage.setItem(
-        CHART_SETTINGS_STORAGE_KEY,
-        JSON.stringify(payload)
-      );
-    } catch (error) {
-      console.warn('No se pudieron guardar los ajustes del gráfico.', error);
-    }
-  }, [chartSettings, fertilityConfig]);
 
   const ignoreNextClickRef = useRef(false);
   const keepFormOpenUntilRef = useRef(0);
@@ -747,7 +650,7 @@ const rotatedDrawerStyle = applyRotation
   const handleFertilityCalculatorChange = (calculatorKey, checked) => {
     let nextConfig = null;
     setChartSettings((prev) => {
-      const currentConfig = mergeFertilityStartConfig(prev.fertilityStartConfig);
+      const currentConfig = mergeFertilityStartConfig({ incoming: prev.fertilityStartConfig });
       const nextValue = checked === true;
       if (currentConfig.calculators?.[calculatorKey] === nextValue) {
         return prev;

--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -44,6 +44,7 @@ import { saveUserMetricsSnapshot } from '@/lib/userMetrics';
 import { MANUAL_CPM_DEDUCTION, buildCpmMetric } from '@/lib/metrics/cpm';
 import { buildT8Metric } from '@/lib/metrics/t8';
 import { getSymbolColorPalette } from '@/config/fertilitySymbols';
+import { mergeFertilityStartConfig, normalizePreferenceValue } from '@/lib/preferences';
 
 const DATA_ENTRY_FORM_DRAFT_KEY = 'dashboard:data-entry-form-draft';
 
@@ -2555,7 +2556,7 @@ const ModernFertilityDashboard = () => {
     if (cpmSelectionInitializedRef.current) return;
     if (!preferences) return;
 
-    let resolvedMode = preferences?.cpmMode;
+    let resolvedMode = normalizePreferenceValue('cpmMode', preferences?.cpmMode);
     if (!['auto', 'manual', 'none'].includes(resolvedMode)) {
       resolvedMode = isManualCpm
         ? 'manual'
@@ -2573,7 +2574,7 @@ const ModernFertilityDashboard = () => {
     if (t8SelectionInitializedRef.current) return;
     if (!preferences) return;
 
-    let resolvedMode = preferences?.t8Mode;
+    let resolvedMode = normalizePreferenceValue('t8Mode', preferences?.t8Mode);
     if (!['auto', 'manual', 'none'].includes(resolvedMode)) {
       resolvedMode = isManualT8
         ? 'manual'
@@ -4099,10 +4100,12 @@ const displayCycles = [...cycles].sort((a, b) => {
   ]);
 
   const fertilityStartConfig = useMemo(
-    () => ({
-      calculators: {
+    () => mergeFertilityStartConfig({
+      incoming: {
+        calculators: {
         cpm: cpmSelection !== 'none',
         t8: t8Selection !== 'none',
+      },
       },
     }),
     [cpmSelection, t8Selection]

--- a/src/pages/PreferencesPage.jsx
+++ b/src/pages/PreferencesPage.jsx
@@ -1,0 +1,257 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { ChevronLeft, SlidersHorizontal } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Checkbox } from '@/components/ui/checkbox';
+import { useToast } from '@/components/ui/use-toast';
+import { useAuth } from '@/contexts/AuthContext';
+import {
+  PREFERENCE_DEFAULTS,
+  PREFERENCES_UI_FIELDS,
+  buildPreferencesDiff,
+  mergeFertilityStartConfig,
+  normalizeStoredPreferences,
+  validatePreferenceField,
+  validatePreferences,
+} from '@/lib/preferences';
+
+const PreferencesPage = () => {
+  const { preferences, savePreferences } = useAuth();
+  const { toast } = useToast();
+  const normalizedPreferences = useMemo(
+    () => normalizeStoredPreferences(preferences ?? PREFERENCE_DEFAULTS),
+    [preferences]
+  );
+  const [draft, setDraft] = useState(normalizedPreferences);
+  const [errors, setErrors] = useState({});
+  const [isSaving, setIsSaving] = useState(false);
+
+  useEffect(() => {
+    setDraft(normalizedPreferences);
+    setErrors({});
+  }, [normalizedPreferences]);
+
+  const diff = useMemo(
+    () => buildPreferencesDiff(normalizedPreferences, draft, PREFERENCES_UI_FIELDS),
+    [draft, normalizedPreferences]
+  );
+
+  const hasChanges = Object.keys(diff).length > 0;
+
+  const updateField = (key, value) => {
+    setDraft((prev) => ({ ...prev, [key]: value }));
+    setErrors((prev) => {
+      const next = { ...prev };
+      const error = validatePreferenceField(key, value, { ...draft, [key]: value });
+      if (error) {
+        next[key] = error;
+      } else {
+        delete next[key];
+      }
+      return next;
+    });
+  };
+
+  const updateFertilityCalculator = (calculatorKey, checked) => {
+    const currentConfig = mergeFertilityStartConfig({ incoming: draft.fertilityStartConfig });
+    const nextConfig = {
+      ...currentConfig,
+      calculators: {
+        ...currentConfig.calculators,
+        [calculatorKey]: checked === true,
+      },
+    };
+    updateField('fertilityStartConfig', nextConfig);
+  };
+
+  const handleCancel = () => {
+    setDraft(normalizedPreferences);
+    setErrors({});
+  };
+
+  const handleSave = async () => {
+    const validationErrors = validatePreferences(draft);
+    setErrors(validationErrors);
+    if (Object.keys(validationErrors).length > 0 || !hasChanges) return;
+
+    setIsSaving(true);
+    try {
+      await savePreferences(diff);
+      toast({ title: 'Preferencias guardadas' });
+    } catch (error) {
+      toast({
+        title: 'No se pudieron guardar las preferencias',
+        description: error?.message || 'Inténtalo de nuevo.',
+        variant: 'destructive',
+      });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <div className="mx-auto w-full max-w-2xl px-4 py-6 pb-24">
+      <div className="mb-4 flex items-center gap-2">
+        <Button asChild variant="ghost" size="icon">
+          <Link to="/settings" aria-label="Volver a ajustes">
+            <ChevronLeft className="h-5 w-5" />
+          </Link>
+        </Button>
+        <h1 className="flex items-center gap-2 text-2xl font-bold text-slate-700">
+          <SlidersHorizontal className="h-6 w-6 text-fertiliapp-fuerte" />
+          Preferencias
+        </h1>
+      </div>
+
+      <div className="space-y-4">
+        <section className="rounded-3xl bg-white/80 p-4 shadow">
+          <h2 className="text-base font-semibold text-slate-700">Registro</h2>
+          <div className="mt-3 space-y-2">
+            <Label htmlFor="preferred-time">Hora preferida de temperatura</Label>
+            <Input
+              id="preferred-time"
+              type="time"
+              value={draft.preferredTemperatureTime || ''}
+              onChange={(event) => updateField('preferredTemperatureTime', event.target.value)}
+            />
+            {errors.preferredTemperatureTime && (
+              <p className="text-xs text-red-500">{errors.preferredTemperatureTime}</p>
+            )}
+          </div>
+        </section>
+
+        <section className="rounded-3xl bg-white/80 p-4 shadow">
+          <h2 className="text-base font-semibold text-slate-700">Cálculo</h2>
+          <div className="mt-3 grid gap-3 sm:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="cpm-mode">Modo CPM</Label>
+              <select
+                id="cpm-mode"
+                className="w-full rounded-xl border border-slate-200 bg-white p-2"
+                value={draft.cpmMode}
+                onChange={(event) => updateField('cpmMode', event.target.value)}
+              >
+                <option value="auto">Automático</option>
+                <option value="manual">Manual</option>
+                <option value="none">Desactivado</option>
+              </select>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="t8-mode">Modo T-8</Label>
+              <select
+                id="t8-mode"
+                className="w-full rounded-xl border border-slate-200 bg-white p-2"
+                value={draft.t8Mode}
+                onChange={(event) => updateField('t8Mode', event.target.value)}
+              >
+                <option value="auto">Automático</option>
+                <option value="manual">Manual</option>
+                <option value="none">Desactivado</option>
+              </select>
+            </div>
+          </div>
+
+          <div className="mt-3 grid gap-3 sm:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="manual-cpm">CPM manual</Label>
+              <Input
+                id="manual-cpm"
+                inputMode="decimal"
+                value={draft.manualCpm ?? ''}
+                onChange={(event) => updateField('manualCpm', event.target.value)}
+              />
+              {errors.manualCpm && <p className="text-xs text-red-500">{errors.manualCpm}</p>}
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="manual-cpm-base">Base CPM manual</Label>
+              <Input
+                id="manual-cpm-base"
+                inputMode="decimal"
+                value={draft.manualCpmBase ?? ''}
+                onChange={(event) => updateField('manualCpmBase', event.target.value)}
+              />
+              {errors.manualCpmBase && <p className="text-xs text-red-500">{errors.manualCpmBase}</p>}
+            </div>
+          </div>
+
+          <div className="mt-3 grid gap-3 sm:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="manual-t8">T-8 manual</Label>
+              <Input
+                id="manual-t8"
+                inputMode="decimal"
+                value={draft.manualT8 ?? ''}
+                onChange={(event) => updateField('manualT8', event.target.value)}
+              />
+              {errors.manualT8 && <p className="text-xs text-red-500">{errors.manualT8}</p>}
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="manual-t8-base">Base T-8 manual</Label>
+              <Input
+                id="manual-t8-base"
+                inputMode="decimal"
+                value={draft.manualT8Base ?? ''}
+                onChange={(event) => updateField('manualT8Base', event.target.value)}
+              />
+              {errors.manualT8Base && <p className="text-xs text-red-500">{errors.manualT8Base}</p>}
+            </div>
+          </div>
+        </section>
+
+        <section className="rounded-3xl bg-white/80 p-4 shadow">
+          <h2 className="text-base font-semibold text-slate-700">Visualización del gráfico</h2>
+          <div className="mt-3 flex items-center justify-between gap-3 rounded-xl border border-slate-200 p-3">
+            <div>
+              <p className="font-medium text-slate-700">Mostrar fila de relaciones</p>
+            </div>
+            <Checkbox
+              checked={Boolean(draft.showRelationsRow)}
+              onCheckedChange={(checked) => updateField('showRelationsRow', checked === true)}
+            />
+          </div>
+        </section>
+
+        <section className="rounded-3xl bg-white/80 p-4 shadow">
+          <h2 className="text-base font-semibold text-slate-700">Inicio de fertilidad</h2>
+          <div className="mt-3 space-y-3">
+            <div className="flex items-center justify-between rounded-xl border border-slate-200 p-3">
+              <Label htmlFor="pref-calc-cpm">Usar CPM</Label>
+              <Checkbox
+                id="pref-calc-cpm"
+                checked={Boolean(draft.fertilityStartConfig?.calculators?.cpm)}
+                onCheckedChange={(checked) => updateFertilityCalculator('cpm', checked)}
+              />
+            </div>
+            <div className="flex items-center justify-between rounded-xl border border-slate-200 p-3">
+              <Label htmlFor="pref-calc-t8">Usar T-8</Label>
+              <Checkbox
+                id="pref-calc-t8"
+                checked={Boolean(draft.fertilityStartConfig?.calculators?.t8)}
+                onCheckedChange={(checked) => updateFertilityCalculator('t8', checked)}
+              />
+            </div>
+            {errors.fertilityStartConfig && (
+              <p className="text-xs text-red-500">{errors.fertilityStartConfig}</p>
+            )}
+            <p className="text-xs text-slate-500">
+              Nota: el modo postparto es por ciclo, no es una preferencia global.
+            </p>
+          </div>
+        </section>
+      </div>
+
+      <div className="sticky bottom-0 mt-6 flex gap-2 bg-gradient-to-t from-pink-50 to-transparent py-3">
+        <Button variant="outline" className="flex-1" onClick={handleCancel}>
+          Cancelar
+        </Button>
+        <Button className="flex-1" disabled={!hasChanges || isSaving} onClick={handleSave}>
+          Guardar cambios
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default PreferencesPage;

--- a/src/pages/SettingsPage.jsx
+++ b/src/pages/SettingsPage.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { motion } from 'framer-motion';
-import { User } from 'lucide-react';
+import { SlidersHorizontal, User } from 'lucide-react';
 import { App } from '@capacitor/app';
 import { useAuth } from '@/contexts/AuthContext';
 import { useToast } from '@/components/ui/use-toast';
@@ -15,6 +15,7 @@ import InstallPrompt from '@/components/InstallPrompt';
 import { ensureHealthConnectPermissions } from '@/lib/healthConnectSync';
 import { useHealthConnect } from '@/contexts/HealthConnectContext.jsx';
 import { cn } from '@/lib/utils';
+import { useNavigate } from 'react-router-dom';
 
 import {
   Dialog,
@@ -27,6 +28,7 @@ import {
 
 const SettingsPage = () => {
   const { user, updateEmail, updatePassword, login, logout } = useAuth();
+  const navigate = useNavigate();
   const { currentCycle, archivedCycles } = useCycleData();
   const { isAvailable, hasPermissions, refreshPermissions, isChecking, isAndroidApp } =
     useHealthConnect();
@@ -349,6 +351,19 @@ const SettingsPage = () => {
             </div>
             <Button onClick={() => setShowExportDialog(true)} className="ml-4">
               Exportar ciclos
+            </Button>
+          </div>
+
+          <div className="bg-white/80 backdrop-blur p-4 rounded-3xl shadow flex items-center justify-between">
+            <div>
+              <p className="text-sm text-slate-500">Preferencias</p>
+              <p className="font-medium text-slate-700">
+                Centro maestro de preferencias globales
+              </p>
+            </div>
+            <Button onClick={() => navigate('/settings/preferences')} className="ml-4 gap-2">
+              <SlidersHorizontal className="h-4 w-4" />
+              Abrir
             </Button>
           </div>
           


### PR DESCRIPTION
### Motivation

- Proveer una subpágina maestra en `/settings/preferences` para editar las preferencias globales del usuario desde un único sitio sin eliminar los editores contextuales existentes.  
- Eliminar ambigüedades de fuente de verdad (p. ej. `localStorage` en Chart) y compartir defaults, validación y lógica de compatibilidad legacy en un solo lugar.  
- Mantener intacta la compatibilidad existente entre `combineMode` y `fertilityStartConfig` y preservar que `postpartumMode` siga siendo por ciclo.  

### Description

- Añadida ruta protegida y lazy load para la nueva página `PreferencesPage` y tarjeta de acceso desde `SettingsPage` (`src/App.jsx`, `src/pages/SettingsPage.jsx`, `src/pages/PreferencesPage.jsx`).  
- Nuevo módulo común `src/lib/preferences/index.js` que centraliza defaults, normalización, merge legacy (`combineMode` ↔ `fertilityStartConfig`), validación por campo y generación de diffs (`buildPreferencesDiff`).  
- Refactor en `AuthContext` para usar el módulo común al cargar y guardar preferencias (normalización en lectura y `normalizePreferencePatch` + `setDoc(..., { merge: true })` en guardado, limpiando `combineMode` legacy cuando corresponde).  
- Ajustes en `ChartPage`, `DashboardPage` y `DataEntryFormFields` para reutilizar la lógica común: `showRelationsRow` y `fertilityStartConfig` toman el perfil (`preferences`) como fuente de verdad (se eliminó la dependencia de `localStorage` como fuente principal) y los editores contextuales siguen existiendo pero alineados con defaults/validación centralizados.  
- Conservación explícita de que `postpartumMode` permanece por ciclo y no forma parte de las preferencias globales.  

### Testing

- Ejecutado `npm run build` (Vite production build) y la compilación completó correctamente; produce los assets de producción sin errores.  
- No se añadieron tests unitarios automáticos; la verificación automática realizada fue la compilación del proyecto y fue satisfactoria.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3ec3df2108333ab1017c158bd3470)