### PR TITLE
Restaurar editor compartido CPM/T-8 con UI y comportamiento completos

### DIFF
--- a/src/components/FertilityCalculatorsEditorDialogs.jsx
+++ b/src/components/FertilityCalculatorsEditorDialogs.jsx
@@ -1,7 +1,14 @@
 import React, { useCallback } from 'react';
 import { Ban, CheckCircle2, ChevronRight, Loader2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 
@@ -24,50 +31,350 @@ const FertilityCalculatorsEditorDialogs = ({ editor, onNavigateToCycleDetails })
 
   return (
     <>
-      <Dialog open={dialogs.isCpmDialogOpen} onOpenChange={(open) => !open && dialogs.handleCloseCpmDialog()}>
+      <Dialog
+        open={dialogs.isCpmDialogOpen}
+        onOpenChange={(open) => {
+          if (!open) dialogs.handleCloseCpmDialog();
+        }}
+      >
         <DialogContent className="flex max-h-[90vh] w-[90vw] max-w-sm flex-col overflow-hidden rounded-3xl border border-rose-100 bg-white/95 p-0 text-gray-800 shadow-xl">
-          <DialogHeader className="space-y-2 px-4 pt-4 text-left"><DialogTitle>Editar CPM</DialogTitle><DialogDescription><div className="text-xs">Puedes usar el valor calculado automáticamente o fijar un valor manual.</div></DialogDescription></DialogHeader>
+          <DialogHeader className="space-y-2 px-4 pt-4 text-left">
+            <DialogTitle>Editar CPM</DialogTitle>
+            <DialogDescription>
+              <div className="text-xs">Puedes usar el valor calculado automáticamente o fijar un valor manual.</div>
+            </DialogDescription>
+          </DialogHeader>
+
           <div className="flex-1 space-y-3 overflow-y-auto px-4 pb-3">
-            <div role="radio" tabIndex={0} onClick={() => dialogs.setCpmSelectionDraft('auto')} onKeyDown={(e) => handleCardKeyDown(e, () => dialogs.setCpmSelectionDraft('auto'))} className={`cursor-pointer rounded-2xl border px-3 py-3 ${dialogs.cpmSelectionDraft === 'auto' ? 'border-emerald-300 bg-emerald-50/60' : 'border-rose-100'}`}>
-              <button type="button" onClick={() => dialogs.setShowCpmDetails((p) => !p)}>{cpmInfo.highlightLabel}</button>
-              {dialogs.showCpmDetails && cpmInfo.detailsAvailable && (
-                <ul className="mt-2 space-y-1">{cpmInfo.cycles.map((cycle, index) => {
-                  const key = cycle.cycleId || cycle.id || `${index}`;
-                  const cycleId = cycle.cycleId || cycle.id;
-                  const isIgnored = Boolean(cycle.isIgnored || cycle.ignoredForAutoCalculations);
-                  const isPending = cycleId ? pendingIgnoredCycleIds.includes(cycleId) : false;
-                  return <li key={key} className="flex gap-2"><button type="button" className="flex-1 text-left" onClick={() => onNavigateToCycleDetails?.(cycle)}>{cycle.dateRangeLabel || cycle.displayName || cycle.name || 'Ciclo'} <ChevronRight className="inline h-3 w-3" /></button><Button type="button" variant="outline" size="xs" disabled={!cycleId || isPending} onClick={() => cycleId && handleToggleCycleIgnore(cycleId, !isIgnored)}>{isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : isIgnored ? <Ban className="h-4 w-4" /> : <CheckCircle2 className="h-4 w-4" />}</Button></li>;
-                })}</ul>
+            <div className="px-3">
+              <div className="flex items-center justify-between gap-3 px-3 py-1">
+                <p className="text-xs font-semibold uppercase tracking-wide text-rose-600">Estado actual</p>
+                <span className={`rounded-full px-3 py-1 text-[11px] font-semibold ${dialogs.cpmStatusMode === 'none' ? 'bg-gray-100 text-gray-600' : 'bg-rose-100 text-rose-700'}`}>
+                  {dialogs.cpmStatusChipLabel}
+                </span>
+              </div>
+            </div>
+
+            <div
+              role="radio"
+              tabIndex={0}
+              onClick={() => dialogs.setCpmSelectionDraft('auto')}
+              onKeyDown={(event) => handleCardKeyDown(event, () => dialogs.setCpmSelectionDraft('auto'))}
+              className={`cursor-pointer rounded-2xl border px-3 py-3 shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-300/70 ${dialogs.cpmSelectionDraft === 'auto' ? 'border-emerald-300 bg-emerald-50/60' : 'border-rose-100 bg-white/80 hover:border-fertiliapp-suave'} ${!cpmInfo.canCompute ? 'opacity-70' : ''}`}
+            >
+              <div className="flex items-start justify-between gap-2">
+                <div className="space-y-1">
+                  <p className="text-sm font-semibold text-rose-900">Cálculo automático</p>
+                  <span className="text-[11px] font-semibold text-rose-600">
+                    {cpmInfo.canCompute && cpmInfo.value !== null
+                      ? `CPM automático: ${dialogs.cpmAutomaticValueLabel} días`
+                      : 'No disponible todavía'}
+                  </span>
+                  <p className="text-[10px] text-rose-600">Basado en tus ciclos completados.</p>
+                </div>
+                <span className={`mt-0.5 flex h-5 w-5 items-center justify-center rounded-full border-2 ${dialogs.cpmSelectionDraft === 'auto' ? 'border-emerald-400 bg-emerald-400' : 'border-fertiliapp-suave bg-white'}`}>
+                  {dialogs.cpmSelectionDraft === 'auto' && <span className="h-2.5 w-2.5 rounded-full bg-white" />}
+                </span>
+              </div>
+
+              <div className="mt-2 rounded-2xl border border-rose-100 bg-rose-50/70 px-3 py-2.5 text-[11px] text-rose-900">
+                <div className="flex flex-wrap items-center gap-2 text-xs font-semibold text-rose-700">
+                  <span>Datos disponibles</span>
+                  <button
+                    type="button"
+                    onClick={() => dialogs.setShowCpmDetails((previous) => !previous)}
+                    className="rounded-full bg-white/70 px-2 py-0.5 text-[11px] font-semibold text-rose-600 transition hover:bg-white/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-300/70"
+                    aria-expanded={dialogs.showCpmDetails}
+                  >
+                    {cpmInfo.highlightLabel}
+                  </button>
+                </div>
+
+                {cpmInfo.summary && <p className="mt-1 text-[11px] text-rose-500">{cpmInfo.summary}</p>}
+                {!cpmInfo.detailsAvailable && (
+                  <p className="mt-1 text-[11px] text-rose-500">Aún no hay ciclos finalizados con fecha de finalización.</p>
+                )}
+
+                {dialogs.showCpmDetails && cpmInfo.detailsAvailable && (
+                  <div className="mt-2 space-y-2">
+                    {cpmInfo.cycles.length > 0 ? (
+                      <ul className="space-y-1">
+                        {cpmInfo.cycles.map((cycle, index) => {
+                          const key = cycle.cycleId || cycle.id || `${cycle.displayName || cycle.name || cycle.startDate || 'cycle'}-${index}`;
+                          const durationText = typeof cycle.duration === 'number' && Number.isFinite(cycle.duration) ? `${cycle.duration} días` : 'duración desconocida';
+                          const isShortest = Boolean(cpmInfo.shortestCycle && cpmInfo.shortestCycle === cycle);
+                          const cycleId = cycle.cycleId || cycle.id;
+                          const isIgnored = Boolean(cycle.isIgnored || cycle.ignoredForAutoCalculations);
+                          const isPending = cycleId ? pendingIgnoredCycleIds.includes(cycleId) : false;
+
+                          return (
+                            <li key={key}>
+                              <div className="flex items-stretch gap-2">
+                                <div className={`flex-1 rounded-2xl border px-3 py-2 shadow-sm transition hover:border-rose-200 hover:bg-white ${isIgnored ? 'border-rose-200 bg-rose-50/80 opacity-80' : 'border-rose-100 bg-white/50'}`}>
+                                  <button
+                                    type="button"
+                                    onClick={() => onNavigateToCycleDetails?.(cycle)}
+                                    className="block w-full rounded-2xl px-1 py-0.5 text-left transition hover:bg-white/60 hover:text-rose-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-300/70"
+                                  >
+                                    <div className="flex items-center justify-between gap-2">
+                                      <p className="text-xs font-semibold text-rose-700">{cycle.dateRangeLabel || cycle.displayName || cycle.name || 'Ciclo sin nombre'}</p>
+                                      <ChevronRight className="h-4 w-4 text-rose-400" aria-hidden="true" />
+                                    </div>
+                                  </button>
+                                  <div className="mt-1 flex flex-wrap items-center justify-between gap-2 text-[11px] text-rose-500">
+                                    <span>Duración: {durationText}</span>
+                                    {isShortest && <span className="rounded-full bg-rose-100 px-2 py-0.5 font-semibold text-rose-600">Ciclo más corto</span>}
+                                  </div>
+                                  {isIgnored && <p className="mt-1 text-[11px] text-rose-400">Ignorado para el cálculo automático.</p>}
+                                </div>
+
+                                <Button
+                                  type="button"
+                                  variant="outline"
+                                  size="xs"
+                                  disabled={!cycleId || isPending}
+                                  onClick={() => cycleId && handleToggleCycleIgnore(cycleId, !isIgnored)}
+                                  className="h-8 w-8 shrink-0 self-center border-transparent bg-transparent p-0"
+                                  title={isIgnored ? 'Incluir ciclo en el cálculo automático' : 'Ignorar ciclo para el cálculo automático'}
+                                  aria-label={isIgnored ? 'Incluir ciclo en el cálculo automático' : 'Ignorar ciclo para el cálculo automático'}
+                                  aria-pressed={isIgnored}
+                                >
+                                  {isPending ? <Loader2 className="h-4 w-4 animate-spin text-rose-500" /> : isIgnored ? <Ban className="h-4 w-4 text-rose-500" /> : <CheckCircle2 className="h-4 w-4 text-green-800/70" />}
+                                </Button>
+                              </div>
+                            </li>
+                          );
+                        })}
+                      </ul>
+                    ) : (
+                      <p className="text-[11px] text-rose-500">Aún no hay ciclos finalizados con fecha de finalización.</p>
+                    )}
+                  </div>
+                )}
+              </div>
+            </div>
+
+            <div
+              role="radio"
+              tabIndex={0}
+              onClick={() => dialogs.setCpmSelectionDraft('manual')}
+              onKeyDown={(event) => handleCardKeyDown(event, () => dialogs.setCpmSelectionDraft('manual'))}
+              className={`cursor-pointer rounded-2xl border px-3 py-3 shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-300/70 ${dialogs.cpmSelectionDraft === 'manual' ? 'border-emerald-300 bg-emerald-50/60' : 'border-rose-100 bg-white/80 hover:border-rose-200'}`}
+            >
+              <div className="flex items-start justify-between gap-2">
+                <p className="text-sm font-semibold text-rose-900">Valor manual</p>
+                <span className={`mt-0.5 flex h-5 w-5 items-center justify-center rounded-full border-2 ${dialogs.cpmSelectionDraft === 'manual' ? 'border-emerald-400 bg-emerald-400' : 'border-rose-300 bg-white'}`}>
+                  {dialogs.cpmSelectionDraft === 'manual' && <span className="h-2.5 w-2.5 rounded-full bg-white" />}
+                </span>
+              </div>
+
+              <div className="mt-3 grid grid-cols-2 gap-2">
+                <div className="space-y-1.5">
+                  <Label htmlFor="manual-cpm-base" className="text-xs text-gray-600">Ciclo más corto</Label>
+                  <Input id="manual-cpm-base" type="number" value={dialogs.manualCpmBaseInput} onChange={dialogs.handleManualCpmBaseInputChange} placeholder="Introduce un entero" aria-describedby={dialogs.manualCpmEditedSide ? 'manual-cpm-helper' : undefined} />
+                  {dialogs.manualCpmBaseError && <p className="text-xs text-red-500">{dialogs.manualCpmBaseError}</p>}
+                </div>
+                <div className="space-y-1.5">
+                  <Label htmlFor="manual-cpm-final" className="text-xs text-gray-600">CPM obtenido</Label>
+                  <Input id="manual-cpm-final" type="number" value={dialogs.manualCpmFinalInput} onChange={dialogs.handleManualCpmFinalInputChange} placeholder="Introduce el valor" aria-describedby={dialogs.manualCpmEditedSide ? 'manual-cpm-helper' : undefined} />
+                  {dialogs.manualCpmFinalError && <p className="text-xs text-red-500">{dialogs.manualCpmFinalError}</p>}
+                </div>
+              </div>
+
+              <div className="mt-3 flex flex-wrap items-end gap-2">
+                {dialogs.manualCpmEditedSide && (
+                  <span id="manual-cpm-helper" className="rounded-full bg-rose-50 px-3 py-1 text-xs font-medium text-rose-600">
+                    {dialogs.manualCpmEditedSide === 'base' ? 'Usando Ciclo más corto como base' : 'Usando CPM (final)'}
+                  </span>
+                )}
+                <Button type="button" variant="outline" onClick={() => dialogs.setShowCpmDeleteDialog(true)} disabled={!dialogs.canDeleteManualCpm} className="h-8 shrink-0 rounded-full border border-rose-200 px-3 text-xs text-rose-600 hover:bg-rose-50 hover:text-rose-700">Borrar</Button>
+              </div>
+
+              {dialogs.isCpmSaveDisabled && dialogs.cpmSelectionDraft === 'manual' && !dialogs.isManualCpm && (
+                <p className="mt-2 text-[11px] text-rose-500">Introduce un valor válido antes de seleccionar.</p>
               )}
             </div>
-            <div role="radio" tabIndex={0} onClick={() => dialogs.setCpmSelectionDraft('manual')} onKeyDown={(e) => handleCardKeyDown(e, () => dialogs.setCpmSelectionDraft('manual'))} className={`cursor-pointer rounded-2xl border px-3 py-3 ${dialogs.cpmSelectionDraft === 'manual' ? 'border-emerald-300 bg-emerald-50/60' : 'border-rose-100'}`}>
-              <div className="grid grid-cols-2 gap-2"><div><Label htmlFor="manual-cpm-base">Ciclo más corto</Label><Input id="manual-cpm-base" value={dialogs.manualCpmBaseInput} onChange={dialogs.handleManualCpmBaseInputChange} /></div><div><Label htmlFor="manual-cpm-final">CPM obtenido</Label><Input id="manual-cpm-final" value={dialogs.manualCpmFinalInput} onChange={dialogs.handleManualCpmFinalInputChange} /></div></div>
-              <Button type="button" variant="outline" onClick={() => dialogs.setShowCpmDeleteDialog(true)} disabled={!dialogs.canDeleteManualCpm}>Borrar</Button>
+
+            <div
+              role="radio"
+              tabIndex={0}
+              onClick={() => dialogs.setCpmSelectionDraft('none')}
+              onKeyDown={(event) => handleCardKeyDown(event, () => dialogs.setCpmSelectionDraft('none'))}
+              className={`cursor-pointer rounded-2xl border px-3 py-2 text-left shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-300/70 ${dialogs.cpmSelectionDraft === 'none' ? 'border-emerald-300 bg-emerald-50/60' : 'border-dashed border-rose-200 bg-white/70 hover:border-rose-300'}`}
+            >
+              <div className="flex items-center justify-between gap-2">
+                <p className="text-sm font-semibold text-rose-900">No usar ningún valor</p>
+                <span className={`mt-0.5 flex h-5 w-5 items-center justify-center rounded-full border-2 ${dialogs.cpmSelectionDraft === 'none' ? 'border-emerald-400 bg-emerald-400' : 'border-rose-300 bg-white'}`}>
+                  {dialogs.cpmSelectionDraft === 'none' && <span className="h-2.5 w-2.5 rounded-full bg-white" />}
+                </span>
+              </div>
             </div>
-            <div role="radio" tabIndex={0} onClick={() => dialogs.setCpmSelectionDraft('none')} onKeyDown={(e) => handleCardKeyDown(e, () => dialogs.setCpmSelectionDraft('none'))} className={`cursor-pointer rounded-2xl border px-3 py-2 ${dialogs.cpmSelectionDraft === 'none' ? 'border-emerald-300 bg-emerald-50/60' : 'border-rose-100'}`}>No usar ningún valor</div>
           </div>
-          <DialogFooter className="px-4 pb-4"><Button type="button" variant="secondary" onClick={dialogs.handleCloseCpmDialog}>Cancelar</Button><Button type="button" onClick={dialogs.handleSaveCpm} disabled={dialogs.isCpmSaveDisabled}>Guardar</Button></DialogFooter>
+
+          <DialogFooter className="mt-0 flex flex-col gap-3 px-4 pb-4">
+            <div className="flex w-full items-center justify-end gap-2">
+              <Button type="button" variant="secondary" onClick={dialogs.handleCloseCpmDialog} className="h-8 rounded-full px-4 text-xs">Cancelar</Button>
+              <Button type="button" onClick={dialogs.handleSaveCpm} disabled={dialogs.isCpmSaveDisabled} className="h-8 rounded-full px-4 text-xs">Guardar</Button>
+            </div>
+          </DialogFooter>
         </DialogContent>
       </Dialog>
 
-      <Dialog open={dialogs.showCpmDeleteDialog} onOpenChange={dialogs.setShowCpmDeleteDialog}><DialogContent className="w-[90vw] max-w-xs rounded-2xl border border-rose-100"><DialogHeader><DialogTitle>¿Estás segura de que quieres borrar el valor manual de CPM?</DialogTitle></DialogHeader><DialogFooter><Button type="button" variant="secondary" onClick={() => dialogs.setShowCpmDeleteDialog(false)}>Cancelar</Button><Button type="button" variant="destructive" onClick={dialogs.handleConfirmCpmDelete} disabled={dialogs.isDeletingManualCpm}>{dialogs.isDeletingManualCpm ? 'Borrando…' : 'Borrar'}</Button></DialogFooter></DialogContent></Dialog>
+      <Dialog open={dialogs.showCpmDeleteDialog} onOpenChange={dialogs.setShowCpmDeleteDialog}>
+        <DialogContent className="w-[90vw] max-w-xs rounded-2xl border border-rose-100">
+          <DialogHeader><DialogTitle>¿Estás segura de que quieres borrar el valor manual de CPM?</DialogTitle></DialogHeader>
+          <DialogFooter className="flex flex-col gap-2 sm:flex-row sm:justify-end sm:gap-3">
+            <Button type="button" variant="secondary" onClick={() => dialogs.setShowCpmDeleteDialog(false)} className="w-full sm:w-auto">Cancelar</Button>
+            <Button type="button" variant="destructive" onClick={dialogs.handleConfirmCpmDelete} disabled={dialogs.isDeletingManualCpm} className="w-full sm:w-auto">{dialogs.isDeletingManualCpm ? 'Borrando…' : 'Borrar'}</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
-      <Dialog open={dialogs.isT8DialogOpen} onOpenChange={(open) => !open && dialogs.handleCloseT8Dialog()}>
+      <Dialog
+        open={dialogs.isT8DialogOpen}
+        onOpenChange={(open) => {
+          if (!open) dialogs.handleCloseT8Dialog();
+        }}
+      >
         <DialogContent className="flex max-h-[90vh] w-[90vw] max-w-sm flex-col overflow-hidden rounded-3xl border border-rose-100 bg-white/95 p-0 text-gray-800 shadow-xl">
-          <DialogHeader className="space-y-2 px-4 pt-4 text-left"><DialogTitle>Editar T-8</DialogTitle><DialogDescription><div className="text-xs">Puedes usar el valor calculado automáticamente o fijar un valor manual.</div></DialogDescription></DialogHeader>
-          <div className="flex-1 space-y-3 overflow-y-auto px-4 pb-3">
-            <div role="radio" tabIndex={0} onClick={() => dialogs.setT8SelectionDraft('auto')} onKeyDown={(e) => handleCardKeyDown(e, () => dialogs.setT8SelectionDraft('auto'))} className={`cursor-pointer rounded-2xl border px-3 py-3 ${dialogs.t8SelectionDraft === 'auto' ? 'border-emerald-300 bg-emerald-50/60' : 'border-rose-100'}`}>
-              <button type="button" onClick={() => dialogs.setShowT8Details((p) => !p)}>{t8Info.highlightLabel}</button>
-              {dialogs.showT8Details && computedT8Data.cycleCount > 0 && <ul className="mt-2 space-y-1">{computedT8Data.cyclesConsidered.map((cycle, index) => { const cycleId = cycle.cycleId || cycle.id; const isIgnored = Boolean(cycle.isIgnored || cycle.ignoredForAutoCalculations); const isPending = cycleId ? pendingIgnoredCycleIds.includes(cycleId) : false; return <li key={`${cycleId || index}`} className="flex gap-2"><button type="button" className="flex-1 text-left" onClick={() => onNavigateToCycleDetails?.(cycle)}>{cycle.dateRangeLabel || cycle.displayName || 'Ciclo'} <ChevronRight className="inline h-3 w-3" /></button><Button type="button" variant="outline" size="xs" disabled={!cycleId || isPending} onClick={() => cycleId && handleToggleCycleIgnore(cycleId, !isIgnored)}>{isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : isIgnored ? <Ban className="h-4 w-4" /> : <CheckCircle2 className="h-4 w-4" />}</Button></li>; })}</ul>}
+          <DialogHeader className="space-y-2 px-4 pt-4 text-left">
+            <DialogTitle>Editar T-8</DialogTitle>
+            <DialogDescription>
+              <div className="text-xs">Puedes usar el valor calculado automáticamente o fijar un valor manual.</div>
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="flex-1 space-y-2 overflow-y-auto px-4 pb-3">
+            <div className="px-3">
+              <div className="flex items-center justify-between gap-3 px-3 py-1">
+                <p className="text-xs font-semibold uppercase tracking-wide text-rose-600">Estado actual</p>
+                <span className={`rounded-full px-3 py-1 text-[11px] font-semibold ${dialogs.t8StatusMode === 'none' ? 'bg-gray-100 text-gray-600' : 'bg-rose-100 text-rose-700'}`}>
+                  {dialogs.t8StatusChipLabel}
+                </span>
+              </div>
             </div>
-            <div role="radio" tabIndex={0} onClick={() => dialogs.setT8SelectionDraft('manual')} onKeyDown={(e) => handleCardKeyDown(e, () => dialogs.setT8SelectionDraft('manual'))} className={`cursor-pointer rounded-2xl border px-3 py-3 ${dialogs.t8SelectionDraft === 'manual' ? 'border-emerald-300 bg-emerald-50/60' : 'border-rose-100'}`}><div className="grid grid-cols-2 gap-2"><div><Label htmlFor="manual-t8-base">Ciclo con subida (día)</Label><Input id="manual-t8-base" value={dialogs.manualT8BaseInput} onChange={dialogs.handleManualT8BaseInputChange} /></div><div><Label htmlFor="manual-t8-final">T-8 manual (día)</Label><Input id="manual-t8-final" value={dialogs.manualT8FinalInput} onChange={dialogs.handleManualT8FinalInputChange} /></div></div><Button type="button" variant="outline" onClick={() => dialogs.setShowT8DeleteDialog(true)} disabled={!dialogs.canDeleteManualT8}>Borrar</Button></div>
-            <div role="radio" tabIndex={0} onClick={() => dialogs.setT8SelectionDraft('none')} onKeyDown={(e) => handleCardKeyDown(e, () => dialogs.setT8SelectionDraft('none'))} className={`cursor-pointer rounded-2xl border px-3 py-2 ${dialogs.t8SelectionDraft === 'none' ? 'border-emerald-300 bg-emerald-50/60' : 'border-rose-100'}`}>No usar ningún valor</div>
+
+            <div role="radio" tabIndex={0} onClick={() => dialogs.setT8SelectionDraft('auto')} onKeyDown={(event) => handleCardKeyDown(event, () => dialogs.setT8SelectionDraft('auto'))} className={`cursor-pointer rounded-2xl border px-3 py-3 shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-300/70 ${dialogs.t8SelectionDraft === 'auto' ? 'border-emerald-300 bg-emerald-50/60' : 'border-rose-100 bg-white/80 hover:border-rose-200'} ${!computedT8Data.canCompute ? 'opacity-70' : ''}`}>
+              <div className="flex items-start justify-between gap-2">
+                <div className="space-y-1">
+                  <p className="text-sm font-semibold text-rose-900">Cálculo automático</p>
+                  <span className="text-[11px] font-semibold text-rose-600">{computedT8Data.canCompute && computedT8Data.value !== null ? `T-8 automático: Día ${dialogs.t8AutomaticValueLabel}` : 'No disponible todavía'}</span>
+                  <p className="text-[10px] text-rose-600">Basado en tus ciclos completados.</p>
+                </div>
+                <span className={`mt-0.5 flex h-5 w-5 items-center justify-center rounded-full border-2 ${dialogs.t8SelectionDraft === 'auto' ? 'border-emerald-400 bg-emerald-400' : 'border-rose-300 bg-white'}`}>{dialogs.t8SelectionDraft === 'auto' && <span className="h-2.5 w-2.5 rounded-full bg-white" />}</span>
+              </div>
+
+              <div className="mt-2 rounded-2xl border border-rose-100 bg-rose-50/70 px-3 py-2.5 text-[11px] text-rose-900">
+                <div className="flex flex-wrap items-center gap-2 text-xs font-semibold text-rose-700">
+                  <span>Datos disponibles</span>
+                  <button type="button" onClick={() => dialogs.setShowT8Details((previous) => !previous)} className="rounded-full bg-white/70 px-2 py-0.5 text-[11px] font-semibold text-rose-600 transition hover:bg-white/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-300/70" aria-expanded={dialogs.showT8Details}>{t8Info.highlightLabel}</button>
+                </div>
+                {t8Info.summary && <p className="mt-1 text-[11px] text-rose-500">{t8Info.summary}</p>}
+                {computedT8Data.cycleCount === 0 && <p className="mt-1 text-[11px] text-rose-500">Aún no hay ciclos con ovulación confirmada por temperatura.</p>}
+
+                {dialogs.showT8Details && computedT8Data.cycleCount > 0 && (
+                  <div className="mt-2 space-y-2">
+                    {computedT8Data.cyclesConsidered.length > 0 ? (
+                      <ul className="space-y-1">
+                        {computedT8Data.cyclesConsidered.map((cycle, index) => {
+                          const key = cycle.cycleId || `${cycle.displayName}-${cycle.riseDay}-${index}`;
+                          const cycleId = cycle.cycleId || cycle.id;
+                          const riseDayText = typeof cycle.riseDay === 'number' && Number.isFinite(cycle.riseDay) ? cycle.riseDay : '—';
+                          const isIgnored = Boolean(cycle.isIgnored || cycle.ignoredForAutoCalculations);
+                          const isPending = cycleId ? pendingIgnoredCycleIds.includes(cycleId) : false;
+
+                          return (
+                            <li key={key}>
+                              <div className="flex items-stretch gap-2">
+                                <div className={`flex-1 rounded-2xl border px-3 py-2 shadow-sm transition hover:border-rose-200 hover:bg-white ${isIgnored ? 'border-rose-200 bg-rose-50/80 opacity-80' : 'border-rose-100 bg-white/40'}`}>
+                                  <button type="button" onClick={() => onNavigateToCycleDetails?.(cycle)} className="block w-full rounded-2xl px-1 py-0.5 text-left transition hover:bg-white/60 hover:text-rose-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-300/70">
+                                    <div className="flex items-center justify-between gap-2">
+                                      <p className="text-xs font-semibold text-rose-700">{cycle.dateRangeLabel || cycle.displayName || cycle.name || 'Ciclo sin nombre'}</p>
+                                      <ChevronRight className="h-4 w-4 text-rose-400" aria-hidden="true" />
+                                    </div>
+                                  </button>
+                                  <div className="mt-1 flex flex-wrap items-center gap-2 text-[11px] text-rose-500">
+                                    <span>Día de subida: {riseDayText}</span>
+                                    {Number.isFinite(cycle.t8Day) && <span>T-8: Día {cycle.t8Day}</span>}
+                                  </div>
+                                  {isIgnored && <p className="mt-1 text-[11px] text-rose-400">Ignorado para el cálculo automático.</p>}
+                                </div>
+
+                                <Button type="button" variant="outline" size="icon" disabled={!cycleId || isPending} onClick={() => cycleId && handleToggleCycleIgnore(cycleId, !isIgnored)} className="h-8 w-8 shrink-0 self-center border-transparent bg-transparent p-0" title={isIgnored ? 'Incluir ciclo en el cálculo automático' : 'Ignorar ciclo para el cálculo automático'} aria-label={isIgnored ? 'Incluir ciclo en el cálculo automático' : 'Ignorar ciclo para el cálculo automático'} aria-pressed={isIgnored}>
+                                  {isPending ? <Loader2 className="h-4 w-4 animate-spin text-rose-500" /> : isIgnored ? <Ban className="h-4 w-4 text-rose-500" /> : <CheckCircle2 className="h-4 w-4 text-green-800/70" />}
+                                </Button>
+                              </div>
+                            </li>
+                          );
+                        })}
+                      </ul>
+                    ) : (
+                      <p className="text-[11px] text-rose-500">Aún no hay ciclos con ovulación confirmada por temperatura.</p>
+                    )}
+                  </div>
+                )}
+              </div>
+            </div>
+
+            <div role="radio" tabIndex={0} onClick={() => dialogs.setT8SelectionDraft('manual')} onKeyDown={(event) => handleCardKeyDown(event, () => dialogs.setT8SelectionDraft('manual'))} className={`cursor-pointer rounded-2xl border px-3 py-3 shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-300/70 ${dialogs.t8SelectionDraft === 'manual' ? 'border-emerald-300 bg-emerald-50/60' : 'border-rose-100 bg-white/80 hover:border-rose-200'}`}>
+              <div className="flex items-start justify-between gap-2">
+                <p className="text-sm font-semibold text-rose-900">Valor manual</p>
+                <span className={`mt-0.5 flex h-5 w-5 items-center justify-center rounded-full border-2 ${dialogs.t8SelectionDraft === 'manual' ? 'border-emerald-400 bg-emerald-400' : 'border-rose-300 bg-white'}`}>{dialogs.t8SelectionDraft === 'manual' && <span className="h-2.5 w-2.5 rounded-full bg-white" />}</span>
+              </div>
+
+              <div className="mt-3 grid grid-cols-2 gap-2">
+                <div className="space-y-1.5">
+                  <Label htmlFor="manual-t8-base" className="text-xs text-gray-600">Ciclo con subida (día)</Label>
+                  <Input id="manual-t8-base" type="number" value={dialogs.manualT8BaseInput} onChange={dialogs.handleManualT8BaseInputChange} placeholder="Día de subida" aria-describedby={dialogs.manualT8EditedSide ? 'manual-t8-helper' : undefined} />
+                  {dialogs.manualT8BaseError && <p className="text-xs text-red-500">{dialogs.manualT8BaseError}</p>}
+                </div>
+                <div className="space-y-1.5">
+                  <Label htmlFor="manual-t8-final" className="text-xs text-gray-600">T-8 manual (día)</Label>
+                  <Input id="manual-t8-final" type="number" value={dialogs.manualT8FinalInput} onChange={dialogs.handleManualT8FinalInputChange} placeholder="Día del T-8" aria-describedby={dialogs.manualT8EditedSide ? 'manual-t8-helper' : undefined} />
+                  {dialogs.manualT8FinalError && <p className="text-xs text-red-500">{dialogs.manualT8FinalError}</p>}
+                </div>
+              </div>
+
+              <div className="mt-3 flex flex-wrap items-end gap-2">
+                {dialogs.manualT8EditedSide && (
+                  <span id="manual-t8-helper" className="rounded-full bg-rose-50 px-3 py-1 text-xs font-medium text-rose-600">
+                    {dialogs.manualT8EditedSide === 'base' ? 'Usando día de subida como base' : 'Usando T-8 manual'}
+                  </span>
+                )}
+                <Button type="button" variant="outline" onClick={() => dialogs.setShowT8DeleteDialog(true)} disabled={!dialogs.canDeleteManualT8} className="h-8 shrink-0 rounded-full border border-rose-200 px-3 text-xs text-rose-600 hover:bg-rose-50 hover:text-rose-700">Borrar</Button>
+              </div>
+
+              {dialogs.isT8SaveDisabled && dialogs.t8SelectionDraft === 'manual' && !dialogs.isManualT8 && (
+                <p className="mt-2 text-[11px] text-rose-500">Introduce un valor válido antes de seleccionar.</p>
+              )}
+            </div>
+
+            <div role="radio" tabIndex={0} onClick={() => dialogs.setT8SelectionDraft('none')} onKeyDown={(event) => handleCardKeyDown(event, () => dialogs.setT8SelectionDraft('none'))} className={`cursor-pointer rounded-2xl border px-3 py-2 text-left shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-300/70 ${dialogs.t8SelectionDraft === 'none' ? 'border-emerald-300 bg-emerald-50/60' : 'border-dashed border-rose-200 bg-white/70 hover:border-rose-300'}`}>
+              <div className="flex items-center justify-between gap-2">
+                <p className="text-sm font-semibold text-rose-900">No usar ningún valor</p>
+                <span className={`mt-0.5 flex h-5 w-5 items-center justify-center rounded-full border-2 ${dialogs.t8SelectionDraft === 'none' ? 'border-emerald-400 bg-emerald-400' : 'border-rose-300 bg-white'}`}>{dialogs.t8SelectionDraft === 'none' && <span className="h-2.5 w-2.5 rounded-full bg-white" />}</span>
+              </div>
+            </div>
           </div>
-          <DialogFooter className="px-4 pb-4"><Button type="button" variant="secondary" onClick={dialogs.handleCloseT8Dialog}>Cancelar</Button><Button type="button" onClick={dialogs.handleSaveT8} disabled={dialogs.isT8SaveDisabled}>Guardar</Button></DialogFooter>
+
+          <DialogFooter className="mt-0 flex flex-col gap-3 px-4 pb-4">
+            <div className="flex w-full items-center justify-end gap-2">
+              <Button type="button" variant="secondary" onClick={dialogs.handleCloseT8Dialog} className="h-8 rounded-full px-4 text-xs">Cancelar</Button>
+              <Button type="button" onClick={dialogs.handleSaveT8} disabled={dialogs.isT8SaveDisabled} className="h-8 rounded-full px-4 text-xs">Guardar</Button>
+            </div>
+          </DialogFooter>
         </DialogContent>
       </Dialog>
 
-      <Dialog open={dialogs.showT8DeleteDialog} onOpenChange={dialogs.setShowT8DeleteDialog}><DialogContent className="w-[90vw] max-w-xs rounded-2xl border border-rose-100"><DialogHeader><DialogTitle>¿Estás segura de que quieres borrar el valor manual de T-8?</DialogTitle></DialogHeader><DialogFooter><Button type="button" variant="secondary" onClick={() => dialogs.setShowT8DeleteDialog(false)}>Cancelar</Button><Button type="button" variant="destructive" onClick={dialogs.handleConfirmT8Delete} disabled={dialogs.isDeletingManualT8}>{dialogs.isDeletingManualT8 ? 'Borrando…' : 'Borrar'}</Button></DialogFooter></DialogContent></Dialog>
+      <Dialog open={dialogs.showT8DeleteDialog} onOpenChange={dialogs.setShowT8DeleteDialog}>
+        <DialogContent className="w-[90vw] max-w-xs rounded-2xl border border-rose-100">
+          <DialogHeader><DialogTitle>¿Estás segura de que quieres borrar el valor manual de T-8?</DialogTitle></DialogHeader>
+          <DialogFooter className="flex flex-col gap-2 sm:flex-row sm:justify-end sm:gap-3">
+            <Button type="button" variant="secondary" onClick={() => dialogs.setShowT8DeleteDialog(false)} className="w-full sm:w-auto">Cancelar</Button>
+            <Button type="button" variant="destructive" onClick={dialogs.handleConfirmT8Delete} disabled={dialogs.isDeletingManualT8} className="w-full sm:w-auto">{dialogs.isDeletingManualT8 ? 'Borrando…' : 'Borrar'}</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </>
   );
 };

--- a/src/hooks/useFertilityCalculatorsEditor.js
+++ b/src/hooks/useFertilityCalculatorsEditor.js
@@ -209,8 +209,25 @@ export const useFertilityCalculatorsEditor = ({
     const normalizedBase = baseValue === undefined ? undefined : baseValue == null ? null : Number(baseValue);
     const payload = { manualCpm: normalizedFinal }; if (normalizedBase !== undefined) payload.manualCpmBase = normalizedBase;
     await savePreferences(payload);
+
+    if (manualCpmStorageKey && typeof window !== 'undefined') {
+      if (payload.manualCpm === null) {
+        localStorage.removeItem(manualCpmStorageKey);
+      } else {
+        localStorage.setItem(manualCpmStorageKey, JSON.stringify({ value: payload.manualCpm }));
+      }
+    }
+
+    if (normalizedBase !== undefined && manualCpmBaseStorageKey && typeof window !== 'undefined') {
+      if (normalizedBase === null) {
+        localStorage.removeItem(manualCpmBaseStorageKey);
+      } else {
+        localStorage.setItem(manualCpmBaseStorageKey, JSON.stringify({ value: normalizedBase }));
+      }
+    }
+
     await saveUserMetricsSnapshot(user.uid, { manual: { cpm: { value: normalizedFinal, base: normalizedBase === undefined ? manualCpmBaseValue : normalizedBase } }, manualUpdatedAt: new Date().toISOString() });
-  }, [manualCpmBaseValue, savePreferences, user?.uid]);
+  }, [manualCpmBaseStorageKey, manualCpmBaseValue, manualCpmStorageKey, savePreferences, user?.uid]);
 
   const persistManualT8 = useCallback(async ({ finalValue, baseValue }) => {
     if (!user?.uid || !savePreferences) return;
@@ -218,8 +235,25 @@ export const useFertilityCalculatorsEditor = ({
     const normalizedBase = baseValue === undefined ? undefined : baseValue == null ? null : Number(baseValue);
     const payload = { manualT8: normalizedFinal }; if (normalizedBase !== undefined) payload.manualT8Base = normalizedBase;
     await savePreferences(payload);
+
+    if (manualT8StorageKey && typeof window !== 'undefined') {
+      if (payload.manualT8 === null) {
+        localStorage.removeItem(manualT8StorageKey);
+      } else {
+        localStorage.setItem(manualT8StorageKey, JSON.stringify({ value: payload.manualT8 }));
+      }
+    }
+
+    if (normalizedBase !== undefined && manualT8BaseStorageKey && typeof window !== 'undefined') {
+      if (normalizedBase === null) {
+        localStorage.removeItem(manualT8BaseStorageKey);
+      } else {
+        localStorage.setItem(manualT8BaseStorageKey, JSON.stringify({ value: normalizedBase }));
+      }
+    }
+
     await saveUserMetricsSnapshot(user.uid, { manual: { t8: { value: normalizedFinal, riseDay: normalizedBase === undefined ? manualT8BaseValue : normalizedBase } }, manualUpdatedAt: new Date().toISOString() });
-  }, [manualT8BaseValue, savePreferences, user?.uid]);
+  }, [manualT8BaseStorageKey, manualT8BaseValue, manualT8StorageKey, savePreferences, user?.uid]);
 
   useEffect(() => {
     if (!manualCpmStorageKey) {
@@ -327,25 +361,153 @@ export const useFertilityCalculatorsEditor = ({
   const t8Metric = useMemo(() => buildT8Metric({ computedT8Data, t8Selection, isManualT8, manualT8BaseValue, manualT8Value, formatNumber }), [computedT8Data, formatNumber, isManualT8, manualT8BaseValue, manualT8Value, t8Selection]);
 
   const cpmInfo = useMemo(() => {
-    const cycles = [...(computedCpmData.cyclesConsidered ?? [])].sort((a, b) => parseISO(b.startDate || '1970-01-01') - parseISO(a.startDate || '1970-01-01'));
     const cycleCount = computedCpmData.cycleCount ?? 0;
-    return {
-      highlightLabel: `${cycleCount} ciclo${cycleCount === 1 ? '' : 's'}`,
-      cycleCount,
-      canCompute: Boolean(computedCpmData.canCompute),
-      detailsAvailable: cycles.length > 0,
-      cycles,
-      shortestCycle: computedCpmData.shortestCycle ?? null,
-      value: typeof computedCpmData.value === 'number' ? computedCpmData.value : null,
-      summary: '',
-    };
-  }, [computedCpmData]);
+    const cyclesLabel = `${cycleCount} ciclo${cycleCount === 1 ? '' : 's'}`;
+    const requiredCycles = 6;
+    const resolvedMode = ['auto', 'manual', 'none'].includes(cpmSelection) ? cpmSelection : 'auto';
+    const sourceLabel =
+      resolvedMode === 'manual' && isManualCpm
+        ? 'Manual'
+        : resolvedMode === 'auto' && computedCpmData.canCompute
+          ? 'Automático'
+          : resolvedMode === 'none'
+            ? 'Sin usar'
+            : 'Automático';
 
-  const t8Info = useMemo(() => ({
-    highlightLabel: `${computedT8Data.cycleCount} ciclo${computedT8Data.cycleCount === 1 ? '' : 's'}`,
-    cycleCount: computedT8Data.cycleCount,
-    summary: '',
-  }), [computedT8Data.cycleCount]);
+    const cycles = computedCpmData.cyclesConsidered ?? [];
+    const displayCycles = [...cycles].sort((a, b) => {
+      const parseSafe = (value) => {
+        if (!value) return null;
+        try {
+          const parsed = parseISO(value);
+          return Number.isNaN(parsed.getTime()) ? null : parsed;
+        } catch {
+          return null;
+        }
+      };
+
+      const startA = parseSafe(a.startDate);
+      const startB = parseSafe(b.startDate);
+
+      if (!startA && !startB) return 0;
+      if (!startA) return 1;
+      if (!startB) return -1;
+      return startB - startA;
+    });
+
+    const canCompute = Boolean(computedCpmData.canCompute);
+    const ignoredCount = computedCpmData.ignoredCount ?? 0;
+    const deduction =
+      typeof computedCpmData.deduction === 'number' && Number.isFinite(computedCpmData.deduction)
+        ? computedCpmData.deduction
+        : null;
+    const shortestCycle = computedCpmData.shortestCycle ?? null;
+    const automaticValue =
+      typeof computedCpmData.value === 'number' && Number.isFinite(computedCpmData.value)
+        ? computedCpmData.value
+        : null;
+
+    let summary;
+    if (cycleCount === 0) {
+      summary = ignoredCount > 0
+        ? 'Todos los ciclos disponibles están ignorados para el cálculo automático.'
+        : 'Aún no hay ciclos finalizados con fecha de finalización.';
+    } else if (!canCompute) {
+      summary = `Hay ${cyclesLabel} finalizado${cycleCount === 1 ? '' : 's'}. Se necesitan ${requiredCycles} para calcular el CPM automáticamente.`;
+      if (ignoredCount > 0) {
+        summary += ` (${ignoredCount} ciclo${ignoredCount === 1 ? '' : 's'} ignorado${ignoredCount === 1 ? '' : 's'}).`;
+      }
+    } else {
+      const cycleName =
+        shortestCycle?.dateRangeLabel || shortestCycle?.displayName || shortestCycle?.name || 'Ciclo sin nombre';
+      const durationText =
+        typeof shortestCycle?.duration === 'number' && Number.isFinite(shortestCycle.duration)
+          ? `${shortestCycle.duration} días`
+          : 'duración desconocida';
+
+      const parts = [
+        `Calculado con ${cyclesLabel}.`,
+        `Ciclo más corto: ${cycleName} (${durationText}).`,
+      ];
+
+      if (deduction !== null) {
+        parts.push(`Deducción aplicada: ${deduction} días.`);
+      }
+      if (automaticValue !== null) {
+        parts.push(`Resultado: ${automaticValue} días.`);
+      }
+      if (ignoredCount > 0) {
+        parts.push(`${ignoredCount} ciclo${ignoredCount === 1 ? '' : 's'} ignorado${ignoredCount === 1 ? '' : 's'}.`);
+      }
+      summary = parts.join(' ');
+    }
+
+    return {
+      sourceLabel,
+      summary,
+      highlightLabel: cyclesLabel,
+      cycleCount,
+      requiredCycles,
+      canCompute,
+      detailsAvailable: displayCycles.length > 0,
+      cycles: displayCycles,
+      deduction,
+      shortestCycle,
+      value: automaticValue,
+      ignoredCount,
+    };
+  }, [computedCpmData, cpmSelection, isManualCpm]);
+
+  const t8Info = useMemo(() => {
+    const cycleCount = computedT8Data.cycleCount;
+    const cyclesLabel = `${cycleCount} ciclo${cycleCount === 1 ? '' : 's'}`;
+    const requiredCycles = 6;
+    const resolvedMode = ['auto', 'manual', 'none'].includes(t8Selection) ? t8Selection : 'auto';
+    const sourceLabel =
+      resolvedMode === 'manual' && isManualT8
+        ? 'Manual'
+        : resolvedMode === 'auto' && computedT8Data.canCompute
+          ? 'Automático'
+          : resolvedMode === 'none'
+            ? 'Sin usar'
+            : 'Automático';
+    const ignoredCount = computedT8Data.ignoredCount ?? 0;
+
+    let summary;
+    if (cycleCount === 0) {
+      summary = ignoredCount > 0
+        ? 'Los ciclos disponibles están ignorados para el cálculo automático.'
+        : 'Aún no hay ciclos con ovulación confirmada por temperatura.';
+    } else if (!computedT8Data.canCompute) {
+      summary = `Hay ${cyclesLabel} con ovulación confirmada por temperatura (se necesitan ${requiredCycles}).`;
+      if (ignoredCount > 0) {
+        summary += ` (${ignoredCount} ciclo${ignoredCount === 1 ? '' : 's'} ignorado${ignoredCount === 1 ? '' : 's'}).`;
+      }
+    } else {
+      const cycleName =
+        computedT8Data.earliestCycle?.displayName || computedT8Data.earliestCycle?.name || 'Ciclo sin nombre';
+      const riseDay = computedT8Data.earliestCycle?.riseDay;
+      const dayText = typeof riseDay === 'number' && Number.isFinite(riseDay) ? `Día ${riseDay}` : 'día desconocido';
+      const t8Day = computedT8Data.earliestCycle?.t8Day;
+      const t8Text = typeof t8Day === 'number' && Number.isFinite(t8Day) ? `T-8 Día ${t8Day}` : null;
+
+      summary = `Calculado con ${cyclesLabel}. Subida más temprana: ${cycleName} (${dayText})${t8Text ? `. ${t8Text}.` : '.'}`;
+      if (ignoredCount > 0) {
+        summary += ` ${ignoredCount} ciclo${ignoredCount === 1 ? '' : 's'} ignorado${ignoredCount === 1 ? '' : 's'}.`;
+      }
+    }
+
+    return {
+      sourceLabel,
+      summary,
+      highlightLabel: cyclesLabel,
+      cycleCount,
+      requiredCycles,
+      canCompute: Boolean(computedT8Data.canCompute),
+      value: typeof computedT8Data.value === 'number' && Number.isFinite(computedT8Data.value) ? computedT8Data.value : null,
+      ignoredCount,
+    };
+  }, [computedT8Data, isManualT8, t8Selection]);
 
   const handleToggleCycleIgnore = useCallback(async (cycleId, shouldIgnore) => {
     if (!cycleId) return;
@@ -385,25 +547,78 @@ export const useFertilityCalculatorsEditor = ({
   const handleSaveManualCpm = useCallback(async () => {
     if (manualCpmBaseError || manualCpmFinalError) return false;
     const trimmedBase = manualCpmBaseInput.trim(); const trimmedFinal = manualCpmFinalInput.trim(); const side = manualCpmEditedSide ?? (trimmedFinal ? 'final' : trimmedBase ? 'base' : null);
-    if (!side) return false;
+    if (!side) {
+      setManualCpmFinalError('Introduce un valor.');
+      return false;
+    }
     let baseValueToPersist = manualCpmBaseValue; let finalValueToPersist;
     if (side === 'base') { const parsedBase = Number.parseInt(trimmedBase, 10); if (!Number.isFinite(parsedBase) || parsedBase < 1) return false; baseValueToPersist = parsedBase; finalValueToPersist = Math.max(1, parsedBase - MANUAL_CPM_DEDUCTION); }
     else { const parsedFinal = Number.parseFloat(trimmedFinal.replace(',', '.')); if (!Number.isFinite(parsedFinal) || parsedFinal < 1) return false; finalValueToPersist = parsedFinal; baseValueToPersist = trimmedBase ? Number.parseInt(trimmedBase, 10) : null; }
-    setManualCpmValue(finalValueToPersist); setIsManualCpm(true); setManualCpmBaseValue(Number.isFinite(baseValueToPersist) ? baseValueToPersist : null);
-    await persistManualCpm({ finalValue: finalValueToPersist, baseValue: baseValueToPersist });
-    setIsCpmDialogOpen(false);
-    return true;
-  }, [manualCpmBaseError, manualCpmBaseInput, manualCpmBaseValue, manualCpmEditedSide, manualCpmFinalError, manualCpmFinalInput, persistManualCpm]);
+    const previousValue = manualCpmValue;
+    const previousIsManual = isManualCpm;
+    const previousBaseValue = manualCpmBaseValue;
+
+    setManualCpmValue(finalValueToPersist);
+    setIsManualCpm(true);
+    setManualCpmBaseValue(Number.isFinite(baseValueToPersist) ? baseValueToPersist : null);
+
+    try {
+      await persistManualCpm({ finalValue: finalValueToPersist, baseValue: baseValueToPersist });
+      setIsCpmDialogOpen(false);
+      toast?.({ title: 'CPM actualizado', description: 'El CPM manual se guardó en tu perfil.' });
+      return true;
+    } catch (error) {
+      console.error('Failed to save manual CPM value', error);
+      setManualCpmValue(previousValue);
+      setManualCpmBaseValue(previousBaseValue);
+      setIsManualCpm(previousIsManual);
+      setManualCpmFinalError('No se pudo guardar el CPM. Inténtalo de nuevo.');
+      return false;
+    }
+  }, [isManualCpm, manualCpmBaseError, manualCpmBaseInput, manualCpmBaseValue, manualCpmEditedSide, manualCpmFinalError, manualCpmFinalInput, manualCpmValue, persistManualCpm, toast]);
 
   const handleSaveCpm = useCallback(async () => {
     if (cpmSelectionDraft === 'manual') { if (!(await handleSaveManualCpm())) return; setCpmSelection('manual'); setCpmSelectionDraft('manual'); await persistCpmMode('manual'); return; }
-    const nextMode = ['auto', 'none'].includes(cpmSelectionDraft) ? cpmSelectionDraft : 'auto'; setCpmSelection(nextMode); setCpmSelectionDraft(nextMode); await persistCpmMode(nextMode); handleCloseCpmDialog();
-  }, [cpmSelectionDraft, handleCloseCpmDialog, handleSaveManualCpm, persistCpmMode]);
+    const nextMode = ['auto', 'none'].includes(cpmSelectionDraft) ? cpmSelectionDraft : 'auto';
+    setCpmSelection(nextMode);
+    setCpmSelectionDraft(nextMode);
+    await persistCpmMode(nextMode);
+    handleCloseCpmDialog();
+
+    toast?.({
+      title: 'CPM actualizado',
+      description: nextMode === 'auto' ? 'Ahora se usa el cálculo automático del CPM.' : 'El CPM ya no se tendrá en cuenta.',
+    });
+  }, [cpmSelectionDraft, handleCloseCpmDialog, handleSaveManualCpm, persistCpmMode, toast]);
 
   const handleDeleteManualCpm = useCallback(async () => {
-    setManualCpmValue(null); setManualCpmBaseValue(null); setIsManualCpm(false); setManualCpmBaseInput(''); setManualCpmFinalInput(''); setManualCpmBaseError(''); setManualCpmFinalError(''); setManualCpmEditedSide(null);
-    await persistManualCpm({ finalValue: null, baseValue: null });
-  }, [persistManualCpm]);
+    const previousValue = manualCpmValue;
+    const previousIsManual = isManualCpm;
+    const previousBaseValue = manualCpmBaseValue;
+
+    setManualCpmValue(null);
+    setManualCpmBaseValue(null);
+    setIsManualCpm(false);
+    setManualCpmBaseInput('');
+    setManualCpmFinalInput('');
+    setManualCpmBaseError('');
+    setManualCpmFinalError('');
+    setManualCpmEditedSide(null);
+
+    try {
+      await persistManualCpm({ finalValue: null, baseValue: null });
+      toast?.({
+        title: 'CPM borrado',
+        description: 'El valor manual se eliminó. Puedes guardar un nuevo valor o continuar con el cálculo automático.',
+      });
+    } catch (error) {
+      console.error('Failed to delete manual CPM value', error);
+      setManualCpmValue(previousValue);
+      setManualCpmBaseValue(previousBaseValue);
+      setIsManualCpm(previousIsManual);
+      setManualCpmFinalError('No se pudo borrar el CPM. Inténtalo de nuevo.');
+    }
+  }, [isManualCpm, manualCpmBaseValue, manualCpmValue, persistManualCpm, toast]);
 
   const handleConfirmCpmDelete = useCallback(async () => {
     setIsDeletingManualCpm(true);
@@ -429,23 +644,78 @@ export const useFertilityCalculatorsEditor = ({
   const handleSaveManualT8 = useCallback(async () => {
     if (manualT8BaseError || manualT8FinalError) return false;
     const trimmedBase = manualT8BaseInput.trim(); const trimmedFinal = manualT8FinalInput.trim(); const side = manualT8EditedSide ?? (trimmedFinal ? 'final' : trimmedBase ? 'base' : null);
-    if (!side) return false;
+    if (!side) {
+      setManualT8FinalError('Introduce un valor.');
+      return false;
+    }
     let baseValueToPersist = manualT8BaseValue; let finalValueToPersist;
     if (side === 'base') { const parsedBase = Number.parseInt(trimmedBase, 10); if (!Number.isFinite(parsedBase) || parsedBase < 1) return false; baseValueToPersist = parsedBase; finalValueToPersist = Math.max(1, parsedBase - 8); }
     else { const parsedFinal = Number.parseInt(trimmedFinal, 10); if (!Number.isFinite(parsedFinal) || parsedFinal < 1) return false; finalValueToPersist = parsedFinal; baseValueToPersist = trimmedBase ? Number.parseInt(trimmedBase, 10) : null; }
-    setManualT8Value(finalValueToPersist); setIsManualT8(true); setManualT8BaseValue(Number.isFinite(baseValueToPersist) ? baseValueToPersist : null);
-    await persistManualT8({ finalValue: finalValueToPersist, baseValue: baseValueToPersist }); setIsT8DialogOpen(false); return true;
-  }, [manualT8BaseError, manualT8BaseInput, manualT8BaseValue, manualT8EditedSide, manualT8FinalError, manualT8FinalInput, persistManualT8]);
+    const previousValue = manualT8Value;
+    const previousIsManual = isManualT8;
+    const previousBaseValue = manualT8BaseValue;
+
+    setManualT8Value(finalValueToPersist);
+    setIsManualT8(true);
+    setManualT8BaseValue(Number.isFinite(baseValueToPersist) ? baseValueToPersist : null);
+
+    try {
+      await persistManualT8({ finalValue: finalValueToPersist, baseValue: baseValueToPersist });
+      setIsT8DialogOpen(false);
+      toast?.({ title: 'T-8 actualizado', description: 'El T-8 manual se guardó en tu perfil.' });
+      return true;
+    } catch (error) {
+      console.error('Failed to save manual T-8 value', error);
+      setManualT8Value(previousValue);
+      setManualT8BaseValue(previousBaseValue);
+      setIsManualT8(previousIsManual);
+      setManualT8FinalError('No se pudo guardar el T-8. Inténtalo de nuevo.');
+      return false;
+    }
+  }, [isManualT8, manualT8BaseError, manualT8BaseInput, manualT8BaseValue, manualT8EditedSide, manualT8FinalError, manualT8FinalInput, manualT8Value, persistManualT8, toast]);
 
   const handleSaveT8 = useCallback(async () => {
     if (t8SelectionDraft === 'manual') { if (!(await handleSaveManualT8())) return; setT8Selection('manual'); setT8SelectionDraft('manual'); await persistT8Mode('manual'); return; }
-    const nextMode = ['auto', 'none'].includes(t8SelectionDraft) ? t8SelectionDraft : 'auto'; setT8Selection(nextMode); setT8SelectionDraft(nextMode); await persistT8Mode(nextMode); handleCloseT8Dialog();
-  }, [handleCloseT8Dialog, handleSaveManualT8, persistT8Mode, t8SelectionDraft]);
+    const nextMode = ['auto', 'none'].includes(t8SelectionDraft) ? t8SelectionDraft : 'auto';
+    setT8Selection(nextMode);
+    setT8SelectionDraft(nextMode);
+    await persistT8Mode(nextMode);
+    handleCloseT8Dialog();
+
+    toast?.({
+      title: 'T-8 actualizado',
+      description: nextMode === 'auto' ? 'Ahora se usa el cálculo automático del T-8.' : 'El T-8 ya no se tendrá en cuenta.',
+    });
+  }, [handleCloseT8Dialog, handleSaveManualT8, persistT8Mode, t8SelectionDraft, toast]);
 
   const handleDeleteManualT8 = useCallback(async () => {
-    setManualT8Value(null); setManualT8BaseValue(null); setIsManualT8(false); setManualT8BaseInput(''); setManualT8FinalInput(''); setManualT8BaseError(''); setManualT8FinalError(''); setManualT8EditedSide(null);
-    await persistManualT8({ finalValue: null, baseValue: null });
-  }, [persistManualT8]);
+    const previousValue = manualT8Value;
+    const previousIsManual = isManualT8;
+    const previousBaseValue = manualT8BaseValue;
+
+    setManualT8Value(null);
+    setManualT8BaseValue(null);
+    setIsManualT8(false);
+    setManualT8BaseInput('');
+    setManualT8FinalInput('');
+    setManualT8BaseError('');
+    setManualT8FinalError('');
+    setManualT8EditedSide(null);
+
+    try {
+      await persistManualT8({ finalValue: null, baseValue: null });
+      toast?.({
+        title: 'T-8 borrado',
+        description: 'El valor manual se eliminó. Puedes guardar un nuevo valor o continuar con el cálculo automático.',
+      });
+    } catch (error) {
+      console.error('Failed to delete manual T-8 value', error);
+      setManualT8Value(previousValue);
+      setManualT8BaseValue(previousBaseValue);
+      setIsManualT8(previousIsManual);
+      setManualT8BaseError('No se pudo borrar el T-8. Inténtalo de nuevo.');
+    }
+  }, [isManualT8, manualT8BaseValue, manualT8Value, persistManualT8, toast]);
 
   const handleConfirmT8Delete = useCallback(async () => {
     setIsDeletingManualT8(true);
@@ -505,6 +775,12 @@ export const useFertilityCalculatorsEditor = ({
       isT8SaveDisabled,
       canDeleteManualCpm: Boolean(isManualCpm || manualCpmBaseInput.trim() || manualCpmFinalInput.trim()),
       canDeleteManualT8: Boolean(isManualT8 || manualT8BaseInput.trim() || manualT8FinalInput.trim()),
+      cpmStatusMode: cpmSelection === 'manual' && isManualCpm ? 'manual' : cpmSelection === 'none' ? 'none' : 'auto',
+      cpmStatusChipLabel: cpmSelection === 'manual' && isManualCpm ? 'Manual' : cpmSelection === 'none' ? 'Sin usar' : 'Automático',
+      t8StatusMode: t8Selection === 'manual' && isManualT8 ? 'manual' : t8Selection === 'none' ? 'none' : 'auto',
+      t8StatusChipLabel: t8Selection === 'manual' && isManualT8 ? 'Manual' : t8Selection === 'none' ? 'Sin usar' : 'Automático',
+      cpmAutomaticValueLabel: typeof cpmInfo.value === 'number' && Number.isFinite(cpmInfo.value) ? cpmInfo.value.toLocaleString('es-ES', { maximumFractionDigits: 2 }) : '—',
+      t8AutomaticValueLabel: typeof t8Info.value === 'number' && Number.isFinite(t8Info.value) ? t8Info.value : '—',
       handleCloseCpmDialog,
       handleCloseT8Dialog,
       handleManualCpmBaseInputChange,


### PR DESCRIPTION
### Motivation
- Recuperar en el editor compartido todo el comportamiento y la UI que tenía el modal completo del Dashboard para CPM y T-8, de forma conservadora y sin duplicar lógica entre páginas.
- Hacer que `Preferences` utilice exactamente el mismo editor que `Dashboard` (misma UI, estados y validaciones) manteniendo la arquitectura compartida existente.

### Description
- Restauré la UI completa del modal en `src/components/FertilityCalculatorsEditorDialogs.jsx`, reintroduciendo chip de estado actual, bloques automático/manual/sin usar, resúmenes detallados, detalle desplegable de ciclos, lista de ciclos considerados, navegación al detalle de ciclo, botones para ignorar/incluir ciclos, helpers y mensajes de validación, flujos de borrado y estados disabled en los botones de guardar.
- En `src/hooks/useFertilityCalculatorsEditor.js` amplié y enriquecí la información expuesta por el hook para soportar la UI completa: `cpmInfo` y `t8Info` con resúmenes, labels de origen, conteos, ciclos ordenados para detalle, valores automáticos formateados y flags auxiliares para los diálogos.
- Restauré la persistencia conservadora de valores manuales (perfil + sincronización a `localStorage`) y añadí manejo robusto en guardado/borrado (rollback en error) y notificaciones con `toast` para igualar el comportamiento previo del Dashboard.
- Mantuve la integración compartida en `DashboardPage.jsx` y `PreferencesPage.jsx` sin duplicar inputs; `PreferencesPage` abre el editor compartido intacto y `Dashboard` sigue usando el mismo hook/componente.

### Testing
- Ejecuté la compilación de producción con `npm run build`, la cual finalizó correctamente sin errores (build completado).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c529b4efa88333b0fc8fe61bed6715)